### PR TITLE
fix description auto-fill on initial invoice modal load

### DIFF
--- a/assets/controllers/invoices_controller.js
+++ b/assets/controllers/invoices_controller.js
@@ -61,6 +61,7 @@ export default class extends Controller {
             onComplete: () => {
                 enableDeletePopover();
                 this.syncFlatPricePerRoomStates();
+                this.syncApartmentDescriptions();
                 const templateSelect = target?.querySelector('#template');
                 if (templateSelect) {
                     const storedTemplateId = getLocalStorageItem('invoice-template-id');
@@ -85,6 +86,7 @@ export default class extends Controller {
             target,
             onComplete: () => {
                 this.syncFlatPricePerRoomStates();
+                this.syncApartmentDescriptions();
                 if (edit) {
                     this.toggleInvoiceEditFields();
                 }
@@ -301,6 +303,14 @@ export default class extends Controller {
             const flat = document.querySelector(flatSelector);
             const perRoom = document.querySelector(perRoomSelector);
             this.applyFlatPriceState(flat, perRoom);
+        });
+    }
+
+    // The `change` handler doesn't fire when only one candidate exists and is auto-selected.
+    syncApartmentDescriptions() {
+        const selects = document.querySelectorAll('select[data-action*="fillApartmentDescriptionAction"]');
+        selects.forEach((select) => {
+            select.dispatchEvent(new Event('change'));
         });
     }
 


### PR DESCRIPTION
Hi, thanks for the project! I am onboarding our Pension on it right now :) looks very nice and polished so far. 

One bug I ran into: The number select in the apartment-position dialog is wired up to a Stimulus `change` handler that fills the Beschreibung field. When the modal opens with a single un-invoiced reservation, the select is auto-selected so no `change` ever fires. Beschreibung stays empty, and with only one option in the list the user has no way to trigger the handler.

Before:

<img width="957" height="924" alt="image" src="https://github.com/user-attachments/assets/1563368a-04e7-4a81-a4ff-828e71e2bcc4" />

After:

<img width="957" height="874" alt="image" src="https://github.com/user-attachments/assets/ad781492-2b6b-47be-8dbe-40e05347164d" />