### PR TITLE
Highlight current day in overview and yearly view

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -616,6 +616,10 @@ body {
     background-color: var(--feb-weekend-bg) !important;
 }
 
+#reservation-table tbody td.reservation-table-today {
+    background-color: rgba(13, 110, 253, 0.08) !important;
+}
+
 
 /* remove bottom border of tr for multiple reservations of one apartment (select tr where the next tr has border-top-0 class) */
 #reservation-table tr:has( + .border-top-0) {

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -620,6 +620,13 @@ body {
     background-color: rgba(13, 110, 253, 0.08) !important;
 }
 
+/* Overlay for today highlight in yearly view */
+.reservation-table-today-overlay {
+    pointer-events: none;
+    z-index: 2;
+    background: rgba(13, 110, 253, 0.18);
+    border-radius: 0.25rem;
+}
 
 /* remove bottom border of tr for multiple reservations of one apartment (select tr where the next tr has border-top-0 class) */
 #reservation-table tr:has( + .border-top-0) {
@@ -677,7 +684,7 @@ div .reservation-yearly-day {
     position: absolute; 
     left: 0; 
     top: 0; 
-    z-index: 2; 
+    z-index: 3; 
     padding: .5rem;
 }
 .month-reservationstartend {

--- a/templates/Reservations/reservation_table.html.twig
+++ b/templates/Reservations/reservation_table.html.twig
@@ -91,6 +91,7 @@
         <tbody>
         {% set totalColumnCount = grid.dayColumns|length * 2 + 1 %}
         {% set emptyTdNr = 0 %}
+        {% set todayDate = 'now'|date('Y-m-d') %}
 
         {% for row in grid.rows %}
             {# Subsidiary group header #}
@@ -122,10 +123,14 @@
 
                 {# ── Cells ── #}
                 {% for cell in row.cells %}
+                    {% set cellEndOffset = cell.startsAtDayBoundary ? ((cell.span - 1) / 2)|round(0, 'floor') : (cell.span / 2)|round(0, 'floor') %}
+                    {% set cellEndDate = cell.date|date_modify('+' ~ cellEndOffset ~ ' day')|date('Y-m-d') %}
+                    {% set isSingleDayCell = cell.span <= 2 %}
+                    {% set todayCss = isSingleDayCell and todayDate >= cell.date and todayDate <= cellEndDate ? ' reservation-table-today' : '' %}
                     {% if cell.type == 'reservation' %}
                         {# Reservation cell #}
                         {% set reservation = cell.reservation %}
-                        <td class="reservation text-center cell-{{ cell.position }}{{ cell.startsAtDayBoundary ? ' day-start' : '' }}"
+                        <td class="reservation text-center cell-{{ cell.position }}{{ cell.startsAtDayBoundary ? ' day-start' : '' }}{{ todayCss }}"
                             colspan="{{ cell.span }}"
                         >
                             <div data-action="click->reservations#openReservationAction"
@@ -139,12 +144,12 @@
                         </td>
                     {% elseif cell.type == 'blocked' %}
                         {# Blocked cell #}
-                        <td class="td-blocked" colspan="{{ cell.span }}">
+                        <td class="td-blocked{{ todayCss }}" colspan="{{ cell.span }}">
                             <div class="blocked-inner"></div>
                         </td>
                     {% else %}
                         {# Empty half-day cell #}
-                        <td class="td-empty td-half td-half-{{ cell.side }}{{ cell.startsAtDayBoundary ? ' day-start' : '' }}"
+                        <td class="td-empty td-half td-half-{{ cell.side }}{{ cell.startsAtDayBoundary ? ' day-start' : '' }}{{ todayCss }}"
                             data-day="{{ cell.date }}" data-appartment="{{ row.apartment.id }}"
                             data-tdnumber="{{ emptyTdNr }}"
                         ></td>

--- a/templates/Reservations/reservation_table_month.html.twig
+++ b/templates/Reservations/reservation_table_month.html.twig
@@ -111,8 +111,8 @@
         {% set todayCss = isToday ? ' reservation-table-today' : '' %}
         <td colspan="2" class="text-center reservation-yearly-parent{{ noEvents }}{{ todayCss }}"
             style="width: {{ 100 / 7}}%" data-day="{{ tmpDate|date("Y-m-d")  }}">
-            <div class="d-flex w-100 h-100 position-relative">
-                {% if isToday %}<div class="reservation-table-today-overlay position-absolute top-0 start-0 w-100 h-100"></div>{% endif %}
+            {% if isToday %}<div class="reservation-table-today-overlay position-absolute top-0 start-0 w-100 h-100"></div>{% endif %}
+            <div class="d-flex w-100 h-100">
                 {{ tdContent|raw }}
             </div>
             <div class="reservation-yearly-day{% if isToday %} fw-bold{% endif %}">{{ tmpDate|date('d') }}</div>

--- a/templates/Reservations/reservation_table_month.html.twig
+++ b/templates/Reservations/reservation_table_month.html.twig
@@ -1,5 +1,7 @@
 {# year and month are provided #}
 {% set startDate = date(year ~ '-' ~ month ~ '-01 UTC') %}
+{# set today date for highlight #}
+{% set todayDate = 'now'|date('Y-m-d') %}
 
 {# this is a dummy date where the first of month is monday which is used for the table header #}
 {% set dummyDate = date('2021-11-01 UTC') %}
@@ -104,10 +106,16 @@
             
             {% set tdContent = tdContent ~ '<div class="' ~ resCss ~'" style="' ~  style ~'"'~ action|raw ~' title="'~ block('popTitle') ~'" data-bs-content="'~ block('popBody')|raw ~'">&nbsp;</div> ' ~ dummyContent %}
         {% endfor %}
-        <td colspan="2" class="text-center reservation-yearly-parent{{ noEvents }}" 
+        {# highlight today with overlay and bold day number #}
+        {% set isToday = tmpDateFormatted == todayDate %}
+        {% set todayCss = isToday ? ' reservation-table-today' : '' %}
+        <td colspan="2" class="text-center reservation-yearly-parent{{ noEvents }}{{ todayCss }}"
             style="width: {{ 100 / 7}}%" data-day="{{ tmpDate|date("Y-m-d")  }}">
-            <div class="d-flex w-100 h-100">{{ tdContent|raw }}</div>
-            <div class="reservation-yearly-day">{{ tmpDate|date('d') }}</div>
+            <div class="d-flex w-100 h-100 position-relative">
+                {% if isToday %}<div class="reservation-table-today-overlay position-absolute top-0 start-0 w-100 h-100"></div>{% endif %}
+                {{ tdContent|raw }}
+            </div>
+            <div class="reservation-yearly-day{% if isToday %} fw-bold{% endif %}">{{ tmpDate|date('d') }}</div>
         </td>
            
         


### PR DESCRIPTION
Sometimes it would be practical to see today date at first glance on the calendar views.

I marked the PR as draft because of two points in the table view. If this feature is desirable I'll try to improve.
- [ ] I am just not super happy that the highlight is not rendered under the reservations.
- [ ] Maybe the day number should be highlighted as well. But there is already holidays and weekends color there.


Table view:
<img width="647" height="650" alt="image" src="https://github.com/user-attachments/assets/05b6de4d-c3b5-4110-9993-eaf422cbee3a" />

Yearly with no reservations:
<img width="369" height="362" alt="image" src="https://github.com/user-attachments/assets/3e237e4c-3b42-40c2-b351-1bdff2ee4dae" />

Yearly with partial reservations:
<img width="369" height="362" alt="image" src="https://github.com/user-attachments/assets/83100836-3e93-4f26-b87b-5653ef53d0bf" />

Yearly with full reservations:
<img width="369" height="362" alt="image" src="https://github.com/user-attachments/assets/a72a080c-8679-4372-856d-168108d2e42c" />

