### PR TITLE
feat: Monat/Jahr-Navigation auf Statistikseiten via Stimulus Controller

### DIFF
--- a/assets/controllers/statistics_controller.js
+++ b/assets/controllers/statistics_controller.js
@@ -582,4 +582,46 @@ export default class extends Controller {
             body: params.toString(),
         });
     }
+
+    // ----- Month/Year navigation -----
+    stepMonthAction(event) {
+        const direction = parseInt(event.params.direction, 10);
+        const monthTargetName = event.params.monthTarget;
+        const yearTargetName  = event.params.yearTarget;
+        const minYear = parseInt(event.params.minYear, 10);
+        const maxYear = parseInt(event.params.maxYear, 10);
+
+        const monthSel = this[`${monthTargetName}Target`];
+        const yearSel  = this[`${yearTargetName}Target`];
+        let month = parseInt(monthSel.value, 10) + direction;
+        let year  = parseInt(yearSel.value, 10);
+
+        if (month < 1) {
+            if (year <= minYear) return;
+            month = 12; year--;
+        } else if (month > 12) {
+            if (year >= maxYear) return;
+            month = 1; year++;
+        }
+
+        monthSel.value = month;
+        yearSel.value  = year;
+        monthSel.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    stepYearAction(event) {
+        const direction  = parseInt(event.params.direction, 10);
+        const targetName = event.params.yearTarget;
+        const minYear    = parseInt(event.params.minYear, 10);
+        const maxYear    = parseInt(event.params.maxYear, 10);
+
+        const sel  = this[`${targetName}Target`];
+        let year   = parseInt(sel.value, 10) + direction;
+
+        if (direction < 0 && year < minYear) return;
+        if (direction > 0 && year > maxYear) return;
+
+        sel.value = year;
+        sel.dispatchEvent(new Event('change', { bubbles: true }));
+    }
 }

--- a/templates/Statistics/reservationorigin.html.twig
+++ b/templates/Statistics/reservationorigin.html.twig
@@ -48,47 +48,55 @@
                     </div>
                     <div class="card-footer pt-0">
                         <form role="form">
-                            <div class="row justify-content-md-center">
-                                <div class="col-md-3">
-                                    <select id="monthlyStart" name="monthtlyStart" class="form-select"
-                                            data-statistics-target="monthlyStart"
-                                            data-action="change->statistics#drawMonthlyOriginAction">
-                                        {% set currentMonth = 'now'|date('n') %}
-                                        {% for month in monthList %}
-                                            <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{% endif %}>{{ month }}</option>
-                                        {% endfor %}
-                                    </select>
+                            <div class="row g-2 align-items-center justify-content-md-center flex-wrap">
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="-1" data-statistics-month-target-param="monthlyStart" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyStart" name="monthlyStart" class="form-select" style="width: 6em;"
+                                                data-statistics-target="monthlyStart"
+                                                data-action="change->statistics#drawMonthlyOriginAction">
+                                            {% set currentMonth = 'now'|date('n') %}
+                                            {% for month in monthList %}
+                                                <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{%endif%}>{{ month }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="1" data-statistics-month-target-param="monthlyStart" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyStartYear" name="monthlyStartYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="monthlyStartYear"
+                                                data-action="change->statistics#drawMonthlyOriginAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
-                                <div class="col-md-2">
-                                    <select id="monthlyStartYear" name="monthtlyStartYear" class="form-select"
-                                            data-statistics-target="monthlyStartYear"
-                                            data-action="change->statistics#drawMonthlyOriginAction">
-                                        {% set currentYear = 'now'|date('Y') %}
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                                <div class="col-md-1 col-form-label text-center">
-                                    -
-                                </div>
-                                <div class="col-md-3">
-                                    <select id="monthlyEnd" name="monthtlyEnd" class="form-select"
-                                            data-statistics-target="monthlyEnd"
-                                            data-action="change->statistics#drawMonthlyOriginAction">
-                                        {% for month in monthList %}
-                                            <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{% endif %}>{{ month }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                                <div class="col-md-2">
-                                    <select id="monthlyEndYear" name="monthtlyEndYear" class="form-select"
-                                            data-statistics-target="monthlyEndYear"
-                                            data-action="change->statistics#drawMonthlyOriginAction">
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                                <div class="col-auto col-form-label">-</div>
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="-1" data-statistics-month-target-param="monthlyEnd" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyEnd" name="monthlyEnd" class="form-select" style="width: 6em"
+                                                data-statistics-target="monthlyEnd"
+                                                data-action="change->statistics#drawMonthlyOriginAction">
+                                            {% set currentMonth = 'now'|date('n') %}
+                                            {% for month in monthList %}
+                                                <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{%endif%}>{{ month }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="1" data-statistics-month-target-param="monthlyEnd" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyEndYear" name="monthlyEndYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="monthlyEndYear"
+                                                data-action="change->statistics#drawMonthlyOriginAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
                             </div>
                         </form>
@@ -109,27 +117,35 @@
                     </div>
                     <div class="card-footer pt-0">
                         <form role="form">
-                            <div class="row justify-content-md-center">
-                                <div class="col-md-2">
-                                    <select id="yearlyStartYear" name="yearlyStartYear" class="form-select"
-                                            data-statistics-target="yearlyStartYear"
-                                            data-action="change->statistics#drawYearlyOriginAction">
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                            <div class="row g-2 align-items-center justify-content-md-center flex-wrap">
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="yearlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="yearlyStartYear" name="yearlyStartYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="yearlyStartYear"
+                                                data-action="change->statistics#drawYearlyOriginAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="yearlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
-                                <div class="col-md-1 col-form-label text-center">
-                                    -
-                                </div>
-                                <div class="col-md-2">
-                                    <select id="yearlyEndYear" name="yearlyEndYear" class="form-select"
-                                            data-statistics-target="yearlyEndYear"
-                                            data-action="change->statistics#drawYearlyOriginAction">
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                                <div class="col-auto col-form-label">-</div>
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="yearlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="yearlyEndYear" name="yearlyEndYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="yearlyEndYear"
+                                                data-action="change->statistics#drawYearlyOriginAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="yearlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
                             </div>
                         </form>

--- a/templates/Statistics/tourism.html.twig
+++ b/templates/Statistics/tourism.html.twig
@@ -46,25 +46,29 @@
                                 {% endfor %}
                             </select>
                         </div>
-                        <div class="col-md-4">
-                            <select id="snapshotMonth" name="snapshotMonth" class="form-select"
-                                    data-statistics-target="snapshotMonth"
-                                    data-action="change->statistics#drawSnapshotAction">
-                                {% set currentMonth = 'now'|date('n') %}
-                                {% for month in monthList %}
-                                    <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{% endif %}>{{ month }}</option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                        <div class="col-md-3">
-                            <select id="snapshotYear" name="snapshotYear" class="form-select"
-                                    data-statistics-target="snapshotYear"
-                                    data-action="change->statistics#drawSnapshotAction">
-                                {% set currentYear = 'now'|date('Y') %}
-                                {% for i in minYear..maxYear %}
-                                    <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                {% endfor %}
-                            </select>
+                        <div class="col-auto">
+                            <div class="input-group">
+                                <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="-1" data-statistics-month-target-param="snapshotMonth" data-statistics-year-target-param="snapshotYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                <select id="snapshotMonth" name="snapshotMonth" class="form-select" style="width: 6em"
+                                        data-statistics-target="snapshotMonth"
+                                        data-action="change->statistics#drawSnapshotAction">
+                                    {% set currentMonth = 'now'|date('n') %}
+                                    {% for month in monthList %}
+                                        <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{%endif%}>{{ month }}</option>
+                                    {% endfor %}
+                                </select>
+                                <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="1" data-statistics-month-target-param="snapshotMonth" data-statistics-year-target-param="snapshotYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="snapshotYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                <select id="snapshotYear" name="snapshotYear" class="form-select" style="width: 4em"
+                                        data-statistics-target="snapshotYear"
+                                        data-action="change->statistics#drawSnapshotAction">
+                                    {% set currentYear = 'now'|date('Y') %}
+                                    {% for i in minYear..maxYear %}
+                                        <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                    {% endfor %}
+                                </select>
+                                <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="snapshotYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                            </div>
                         </div>
                     </div>
                 </form>

--- a/templates/Statistics/turnover.html.twig
+++ b/templates/Statistics/turnover.html.twig
@@ -27,28 +27,35 @@
                     </div>
                     <div class="card-footer pt-0">
                         <form role="form">
-                            <div class="row justify-content-md-center">
-                                <div class="col-md-2">
-                                    <select id="monthlyStartYear" name="monthtlyStartYear" class="form-select"
-                                            data-statistics-target="monthlyStartYear"
-                                            data-action="change->statistics#drawMonthlyTurnoverAction">
-                                        {% set currentYear = 'now'|date('Y') %}
-                                        {% for i in maxYear..minYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                            <div class="row g-2 align-items-center justify-content-md-center flex-wrap">
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyStartYear" name="monthlyStartYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="monthlyStartYear"
+                                                data-action="change->statistics#drawMonthlyTurnoverAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in maxYear..minYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
-                                <div class="col-md-1 col-form-label text-center">
-                                    -
-                                </div>
-                                <div class="col-md-2">
-                                    <select id="monthlyEndYear" name="monthtlyEndYear" class="form-select"
-                                            data-statistics-target="monthlyEndYear"
-                                            data-action="change->statistics#drawMonthlyTurnoverAction">
-                                        {% for i in maxYear..minYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                                <div class="col-auto col-form-label">-</div>
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyEndYear" name="monthlyEndYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="monthlyEndYear"
+                                                data-action="change->statistics#drawMonthlyTurnoverAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in maxYear..minYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
                             </div>
                         </form>
@@ -67,27 +74,35 @@
                     </div>
                     <div class="card-footer pt-0">
                         <form role="form">
-                            <div class="row justify-content-md-center">
-                                <div class="col-md-2">
-                                    <select id="yearlyStartYear" name="yearlyStartYear" class="form-select"
-                                            data-statistics-target="yearlyStartYear"
-                                            data-action="change->statistics#drawYearlyTurnoverAction">
-                                        {% for i in maxYear..minYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                            <div class="row g-2 align-items-center justify-content-md-center flex-wrap">
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="yearlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="yearlyStartYear" name="yearlyStartYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="yearlyStartYear"
+                                                data-action="change->statistics#drawYearlyTurnoverAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in maxYear..minYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="yearlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
-                                <div class="col-md-1 col-form-label text-center">
-                                    -
-                                </div>
-                                <div class="col-md-2">
-                                    <select id="yearlyEndYear" name="yearlyEndYear" class="form-select"
-                                            data-statistics-target="yearlyEndYear"
-                                            data-action="change->statistics#drawYearlyTurnoverAction">
-                                        {% for i in maxYear..minYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                                <div class="col-auto col-form-label">-</div>
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="yearlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="yearlyEndYear" name="yearlyEndYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="yearlyEndYear"
+                                                data-action="change->statistics#drawYearlyTurnoverAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in maxYear..minYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="yearlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
                             </div>
                         </form>

--- a/templates/Statistics/utilization.html.twig
+++ b/templates/Statistics/utilization.html.twig
@@ -48,47 +48,55 @@
                     </div>
                     <div class="card-footer pt-0">
                         <form role="form">
-                            <div class="row justify-content-md-center">
-                                <div class="col-md-3">
-                                    <select id="monthlyStart" name="monthtlyStart" class="form-select"
-                                            data-statistics-target="monthlyStart"
-                                            data-action="change->statistics#drawMonthlyUtilizationAction">
-                                        {% set currentMonth = 'now'|date('n') %}
-                                        {% for month in monthList %}
-                                            <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{% endif %}>{{ month }}</option>
-                                        {% endfor %}
-                                    </select>
+                            <div class="row g-2 align-items-center justify-content-md-center flex-wrap">
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="-1" data-statistics-month-target-param="monthlyStart" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyStart" name="monthlyStart" class="form-select" style="width: 6em"
+                                                data-statistics-target="monthlyStart"
+                                                data-action="change->statistics#drawMonthlyUtilizationAction">
+                                            {% set currentMonth = 'now'|date('n') %}
+                                            {% for month in monthList %}
+                                                <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{%endif%}>{{ month }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="1" data-statistics-month-target-param="monthlyStart" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyStartYear" name="monthlyStartYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="monthlyStartYear"
+                                                data-action="change->statistics#drawMonthlyUtilizationAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="monthlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
-                                <div class="col-md-2">
-                                    <select id="monthlyStartYear" name="monthtlyStartYear" class="form-select"
-                                            data-statistics-target="monthlyStartYear"
-                                            data-action="change->statistics#drawMonthlyUtilizationAction">
-                                        {% set currentYear = 'now'|date('Y') %}
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                                <div class="col-md-1 col-form-label text-center">
-                                    -
-                                </div>
-                                <div class="col-md-3">
-                                    <select id="monthlyEnd" name="monthtlyEnd" class="form-select"
-                                            data-statistics-target="monthlyEnd"
-                                            data-action="change->statistics#drawMonthlyUtilizationAction">
-                                        {% for month in monthList %}
-                                            <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{% endif %}>{{ month }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                                <div class="col-md-2">
-                                    <select id="monthlyEndYear" name="monthtlyEndYear" class="form-select"
-                                            data-statistics-target="monthlyEndYear"
-                                            data-action="change->statistics#drawMonthlyUtilizationAction">
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                                <div class="col-auto col-form-label">-</div>
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="-1" data-statistics-month-target-param="monthlyEnd" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyEnd" name="monthlyEnd" class="form-select" style="width: 6em"
+                                                data-statistics-target="monthlyEnd"
+                                                data-action="change->statistics#drawMonthlyUtilizationAction">
+                                            {% set currentMonth = 'now'|date('n') %}
+                                            {% for month in monthList %}
+                                                <option value="{{ loop.index }}"{%if loop.index == currentMonth %} selected="selected"{%endif%}>{{ month }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link px-1" data-action="click->statistics#stepMonthAction" data-statistics-direction-param="1" data-statistics-month-target-param="monthlyEnd" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="monthlyEndYear" name="monthlyEndYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="monthlyEndYear"
+                                                data-action="change->statistics#drawMonthlyUtilizationAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="monthlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
                             </div>
                         </form>
@@ -109,27 +117,35 @@
                     </div>
                     <div class="card-footer pt-0">
                         <form role="form">
-                            <div class="row justify-content-md-center">
-                                <div class="col-md-2">
-                                    <select id="yearlyStartYear" name="yearlyStartYear" class="form-select"
-                                            data-statistics-target="yearlyStartYear"
-                                            data-action="change->statistics#drawYearlyUtilizationAction">
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                            <div class="row g-2 align-items-center justify-content-md-center flex-wrap">
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="yearlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="yearlyStartYear" name="yearlyStartYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="yearlyStartYear"
+                                                data-action="change->statistics#drawYearlyUtilizationAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="yearlyStartYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
-                                <div class="col-md-1 col-form-label text-center">
-                                    -
-                                </div>
-                                <div class="col-md-2">
-                                    <select id="yearlyEndYear" name="yearlyEndYear" class="form-select"
-                                            data-statistics-target="yearlyEndYear"
-                                            data-action="change->statistics#drawYearlyUtilizationAction">
-                                        {% for i in minYear..maxYear %}
-                                            <option value="{{ i }}"{%if i == currentYear %} selected="selected"{% endif %}>{{ i }}</option>
-                                        {% endfor %}
-                                    </select>
+                                <div class="col-auto col-form-label">-</div>
+                                <div class="col-auto">
+                                    <div class="input-group">
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="-1" data-statistics-year-target-param="yearlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-left fa-xs"></i></button>
+                                        <select id="yearlyEndYear" name="yearlyEndYear" class="form-select" style="width: 4em"
+                                                data-statistics-target="yearlyEndYear"
+                                                data-action="change->statistics#drawYearlyUtilizationAction">
+                                            {% set currentYear = 'now'|date('Y') %}
+                                            {% for i in minYear..maxYear %}
+                                                <option value="{{ i }}"{%if i == currentYear %} selected="selected"{%endif%}>{{ i }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="button" class="btn btn-link p-0" data-action="click->statistics#stepYearAction" data-statistics-direction-param="1" data-statistics-year-target-param="yearlyEndYear" data-statistics-min-year-param="{{ minYear }}" data-statistics-max-year-param="{{ maxYear }}"><i class="fas fa-chevron-right fa-xs"></i></button>
+                                    </div>
                                 </div>
                             </div>
                         </form>


### PR DESCRIPTION
> Statistik: Bitte JS Code in den Templates vermeiden. Das wird mittlerweile alles via sog. Stimulus Controller geregelt. Falls du da noch Fragen hast, meld dich einfach. Der jetzige JS Code scheint auch in allen Dateien gleich zu sein. Codedublikate vermeiden.

Fügt Vor/Zurück-Navigationsschaltflächen (‹ ›) zu allen Monat- und Jahr-Selects auf den Statistik-Unterseiten (Tourismus, Auslastung, Reservierungsherkunft, Umsätze) hinzu. Die Logik wurde von inline JavaScript in den bestehenden Stimulus statistics_controller.js über zwei neue Actions (stepMonthAction, stepYearAction) verschoben.
Hinweis: Aktuell wird inline CSS (style="width: ...") verwendet, um ein Stauchen der Selects zu verhindern - mit dieser Lösung bin ich noch nicht zufrieden und suche nach einer besseren Möglichkeit, dies mit Bootstrap-Mitteln zu lösen.