### PR TITLE
feat: show reservation history on customer detail view

### DIFF
--- a/assets/controllers/customers_controller.js
+++ b/assets/controllers/customers_controller.js
@@ -56,7 +56,7 @@ export default class extends Controller {
         if (!url) {
             return;
         }
-        setModalTitle(title);
+        if (title) setModalTitle(title);
         const target = document.getElementById('modal-content-ajax');
         
         httpRequest({

--- a/assets/controllers/customers_controller.js
+++ b/assets/controllers/customers_controller.js
@@ -65,7 +65,9 @@ export default class extends Controller {
             target,
             onSuccess: (html) => {
                 target.innerHTML = html;
-                initReservationHistoryPagination();
+                // rAF stellt sicher, dass Bootstrap das neue DOM
+                // registriert hat, bevor Listener angehängt werden
+                requestAnimationFrame(() => initReservationHistoryPagination());
             }
         });
     }
@@ -99,6 +101,11 @@ function initReservationHistoryPagination() {
     const tbody = document.querySelector('#reservationHistoryCollapse tbody');
     if (!tbody) return;
     const rows = Array.from(tbody.querySelectorAll('tr'));
+
+    // Alten Pager aus vorherigem Modal-Aufruf entfernen
+    const oldPager = document.getElementById('res-history-pager');
+    if (oldPager) oldPager.remove();
+
     if (rows.length <= perPage) return;
 
     let currentPage = 1;

--- a/assets/controllers/customers_controller.js
+++ b/assets/controllers/customers_controller.js
@@ -56,7 +56,7 @@ export default class extends Controller {
         if (!url) {
             return;
         }
-        if (title) setModalTitle(title);
+        setModalTitle(title);
         const target = document.getElementById('modal-content-ajax');
         
         httpRequest({

--- a/assets/controllers/customers_controller.js
+++ b/assets/controllers/customers_controller.js
@@ -63,6 +63,10 @@ export default class extends Controller {
             url,
             method: 'GET',
             target,
+            onSuccess: (html) => {
+                target.innerHTML = html;
+                initReservationHistoryPagination();
+            }
         });
     }
 
@@ -89,3 +93,64 @@ export default class extends Controller {
         });
     }
 }
+
+function initReservationHistoryPagination() {
+    const perPage = 10;
+    const tbody = document.querySelector('#reservationHistoryCollapse tbody');
+    if (!tbody) return;
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    if (rows.length <= perPage) return;
+
+    let currentPage = 1;
+    const pages = Math.ceil(rows.length / perPage);
+
+    function showPage(page) {
+        currentPage = page;
+        rows.forEach((row, i) => {
+            row.style.display = (i >= (page-1)*perPage && i < page*perPage) ? '' : 'none';
+        });
+        renderPager();
+    }
+
+    function renderPager() {
+        let pager = document.getElementById('res-history-pager');
+        if (!pager) {
+            pager = document.createElement('div');
+            pager.id = 'res-history-pager';
+            pager.className = 'px-3 py-2';
+            document.querySelector('#reservationHistoryCollapse .accordion-body').appendChild(pager);
+        }
+        pager.innerHTML = '';
+        const ul = document.createElement('ul');
+        ul.className = 'pagination pagination-sm mb-0';
+
+        const prev = document.createElement('li');
+        prev.className = 'page-item' + (currentPage === 1 ? ' disabled' : '');
+        prev.innerHTML = '<a class="page-link" href="#">&laquo;</a>';
+        if (currentPage > 1) prev.querySelector('a').addEventListener('click', e => { e.preventDefault(); showPage(currentPage-1); });
+        ul.appendChild(prev);
+
+        for (let i = 1; i <= pages; i++) {
+            const li = document.createElement('li');
+            li.className = 'page-item' + (i === currentPage ? ' active' : '');
+            const p = i;
+            li.innerHTML = '<a class="page-link" href="#">' + i + '</a>';
+            li.querySelector('a').addEventListener('click', e => { e.preventDefault(); showPage(p); });
+            ul.appendChild(li);
+        }
+
+        const next = document.createElement('li');
+        next.className = 'page-item' + (currentPage === pages ? ' disabled' : '');
+        next.innerHTML = '<a class="page-link" href="#">&raquo;</a>';
+        if (currentPage < pages) next.querySelector('a').addEventListener('click', e => { e.preventDefault(); showPage(currentPage+1); });
+        ul.appendChild(next);
+        pager.appendChild(ul);
+    }
+
+    const collapse = document.getElementById('reservationHistoryCollapse');
+    if (collapse) {
+        collapse.addEventListener('shown.bs.collapse', () => showPage(1), { once: true });
+        if (collapse.classList.contains('show')) showPage(1);
+    }
+}
+

--- a/src/Controller/CustomerServiceController.php
+++ b/src/Controller/CustomerServiceController.php
@@ -17,6 +17,7 @@ use App\Entity\Customer;
 use App\Entity\CustomerAddresses;
 use App\Entity\Enum\IDCardType;
 use App\Entity\Template;
+use App\Repository\ReservationRepository;
 use App\Service\CSRFProtectionService;
 use App\Service\CustomerService;
 use App\Service\TemplatesService;
@@ -100,14 +101,23 @@ class CustomerServiceController extends AbstractController
     }
 
     #[Route('/{id}/get', name: 'customers.get.customer', methods: ['GET'], defaults: ['id' => '0'])]
-    public function getCustomerAction(ManagerRegistry $doctrine, CSRFProtectionService $csrf, $id)
-    {
+    public function getCustomerAction(
+        ManagerRegistry $doctrine,
+        CSRFProtectionService $csrf,
+        ReservationRepository $reservationRepo,
+        $id
+    ) {
         $em = $doctrine->getManager();
         $customer = $em->getRepository(Customer::class)->find($id);
 
+        $reservations = $customer
+            ? $reservationRepo->loadAllReservationsForCustomer($customer)
+            : [];
+
         return $this->render('Customers/customer_form_show.html.twig', [
-            'customer' => $customer,
-            'token' => $csrf->getCSRFTokenForForm(),
+            'customer'     => $customer,
+            'token'        => $csrf->getCSRFTokenForForm(),
+            'reservations' => $reservations,
         ]);
     }
 

--- a/src/Repository/ReservationRepository.php
+++ b/src/Repository/ReservationRepository.php
@@ -523,13 +523,15 @@ class ReservationRepository extends ServiceEntityRepository
     public function loadAllReservationsForCustomer(\App\Entity\Customer $customer): array
     {
         return $this->createQueryBuilder('r')
-            ->select('r', 'a', 'rs')
+            ->select('r', 'a', 'rs', 'i')
             ->leftJoin('r.appartment', 'a')
             ->leftJoin('r.reservationStatus', 'rs')
+            ->leftJoin('r.invoices', 'i')
             ->where('r.booker = :customer')
             ->orWhere(':customer MEMBER OF r.customers')
             ->setParameter('customer', $customer)
             ->orderBy('r.startDate', 'DESC')
+            ->distinct()
             ->getQuery()
             ->getResult();
     }

--- a/src/Repository/ReservationRepository.php
+++ b/src/Repository/ReservationRepository.php
@@ -513,4 +513,24 @@ class ReservationRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Alle Reservierungen eines Gastes – als Buchender (booker)
+     * oder als Mitreisender – dedupliziert, nach Anreise absteigend.
+     *
+     * @return Reservation[]
+     */
+    public function loadAllReservationsForCustomer(\App\Entity\Customer $customer): array
+    {
+        return $this->createQueryBuilder('r')
+            ->select('r', 'a', 'rs')
+            ->leftJoin('r.appartment', 'a')
+            ->leftJoin('r.reservationStatus', 'rs')
+            ->where('r.booker = :customer')
+            ->orWhere(':customer MEMBER OF r.customers')
+            ->setParameter('customer', $customer)
+            ->orderBy('r.startDate', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/templates/Customers/customer_form_show.html.twig
+++ b/templates/Customers/customer_form_show.html.twig
@@ -16,7 +16,6 @@
     <div class="row">
         {% include 'Customers/_show_info.html.twig' with {'customer' : customer} %}
     </div>
-        {% include 'Customers/customer_show_address_fields_short.html.twig' with {'customer' : customer} %}
         {% include 'Customers/customer_reservation_history.html.twig' with {'reservations': reservations} %}
 </div>
 

--- a/templates/Customers/customer_form_show.html.twig
+++ b/templates/Customers/customer_form_show.html.twig
@@ -17,6 +17,7 @@
         {% include 'Customers/_show_info.html.twig' with {'customer' : customer} %}
     </div>
         {% include 'Customers/customer_show_address_fields_short.html.twig' with {'customer' : customer} %}
+        {% include 'Customers/customer_reservation_history.html.twig' with {'reservations': reservations} %}
 </div>
 
 <form id="customer-form-{{ customer.id }}"

--- a/templates/Customers/customer_form_show.html.twig
+++ b/templates/Customers/customer_form_show.html.twig
@@ -16,7 +16,9 @@
     <div class="row">
         {% include 'Customers/_show_info.html.twig' with {'customer' : customer} %}
     </div>
-        {% include 'Customers/customer_reservation_history.html.twig' with {'reservations': reservations} %}
+    {% include 'Customers/customer_show_address_fields_short.html.twig' with {'customer' : customer} %}
+    {% include 'Customers/customer_reservation_history.html.twig' with {'reservations': reservations} %}
+
 </div>
 
 <form id="customer-form-{{ customer.id }}"

--- a/templates/Customers/customer_reservation_history.html.twig
+++ b/templates/Customers/customer_reservation_history.html.twig
@@ -61,7 +61,7 @@
                                                                 <a href="#"
                                                                 data-action="click->customers#openModalAction"
                                                                 data-url="{{ path('reservations.get.reservation', {id: res.id}) }}"
-                                                                data-title="{{ 'reservation.details'|trans ~ ' ' ~ res.id }}"
+                                                                data-title="{{ 'reservation.details'|trans }}"
                                                                 class="btn btn-sm btn-outline-secondary py-0"
                                                                 title="{{ 'reservation.details'|trans }}">
                                                                     <i class="fas fa-external-link-alt"></i>

--- a/templates/Customers/customer_reservation_history.html.twig
+++ b/templates/Customers/customer_reservation_history.html.twig
@@ -1,0 +1,81 @@
+                <div class="row mt-3">
+                    <div class="col">
+                        <div class="accordion accordion-flush" id="reservationHistoryAccordion">
+                            <div class="accordion-item">
+                                <h2 class="accordion-header" id="reservationHistoryHeading">
+                                    <button class="accordion-button collapsed" type="button"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#reservationHistoryCollapse"
+                                            aria-expanded="false"
+                                            aria-controls="reservationHistoryCollapse">
+                                        {{ 'customer.reservation.history'|trans }}
+                                        <span class="badge bg-secondary ms-2">{{ reservations|length }}</span>
+                                    </button>
+                                </h2>
+                                <div id="reservationHistoryCollapse"
+                                    class="accordion-collapse collapse"
+                                    aria-labelledby="reservationHistoryHeading"
+                                    data-bs-parent="#reservationHistoryAccordion">
+                                    <div class="accordion-body p-0">
+                                        {% if reservations is empty %}
+                                            <p class="text-muted small p-3 mb-0">{{ 'customer.reservation.history.empty'|trans }}</p>
+                                        {% else %}
+                                            <div class="table-responsive">
+                                                <table class="table table-sm table-hover mb-0">
+                                                    <thead class="table-light">
+                                                        <tr>
+                                                            <th>{{ 'housekeeping.summary.arrive'|trans({}, 'Housekeeping') }}</th>
+                                                            <th>{{ 'housekeeping.summary.depart'|trans({}, 'Housekeeping') }}</th>
+                                                            <th>{{ 'registrationbook.stays'|trans }}</th>
+                                                            <th>{{ 'statistics.tourism.room_label'|trans }}</th>
+                                                            <th>{{ 'reservation.status'|trans }}</th>
+                                                            <th>{{ 'invoice.number.short'|trans }}</th>
+                                                            <th></th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        {% for res in reservations %}
+                                                        <tr class="{{ res.reservationStatus and res.reservationStatus.id == 3 ? 'text-muted' : '' }}">
+                                                            <td>{{ res.startDate|date('d.m.y') }}</td>
+                                                            <td>{{ res.endDate|date('d.m.y') }}</td>
+                                                            <td>{{ res.amount }}</td>
+                                                            <td>{{ res.appartment ? res.appartment.number ~ ' ' ~ res.appartment.description : '–' }}</td>
+                                                            <td>{{ res.reservationStatus ? res.reservationStatus.name : '–' }}</td>
+                                                            <td>
+                                                                {% if res.invoices is empty %}
+                                                                    <span class="text-muted">–</span>
+                                                                {% else %}
+                                                                    {% for invoice in res.invoices %}
+                                                                        <a href="#"
+                                                                        data-action="click->customers#openModalAction"
+                                                                        data-url="{{ path('invoices.get.invoice', {id: invoice.id}) }}"
+                                                                        data-title="{{ invoice.number }}"
+                                                                        class="text-decoration-none {{ invoice.status == 1 ? 'text-danger' : (invoice.status == 2 ? 'text-success' : (invoice.status == 3 ? 'text-warning' : 'text-muted')) }}"
+                                                                        title="{{ ('invoice.status.' ~ (invoice.status == 1 ? 'unpaid' : invoice.status == 2 ? 'paid' : invoice.status == 3 ? 'prepaid' : 'canceled'))|trans }}">
+                                                                            {{ invoice.number ? invoice.number : '–' }}
+                                                                        </a>{% if not loop.last %}<br>{% endif %}
+                                                                    {% endfor %}
+                                                                {% endif %}
+                                                            </td>
+                                                            <td>
+                                                                <a href="#"
+                                                                data-action="click->customers#openModalAction"
+                                                                data-url="{{ path('reservations.get.reservation', {id: res.id}) }}"
+                                                                data-title="{{ 'reservation.details'|trans ~ ' ' ~ res.id }}"
+                                                                class="btn btn-sm btn-outline-secondary py-0"
+                                                                title="{{ 'reservation.details'|trans }}">
+                                                                    <i class="fas fa-external-link-alt"></i>
+                                                                </a>
+                                                            </td>
+                                                        </tr>
+                                                        {% endfor %}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>

--- a/templates/Customers/customer_reservation_history.html.twig
+++ b/templates/Customers/customer_reservation_history.html.twig
@@ -49,7 +49,7 @@
                                                                         <a href="#"
                                                                         data-action="click->customers#openModalAction"
                                                                         data-url="{{ path('invoices.get.invoice', {id: invoice.id}) }}"
-                                                                        data-title="{{ invoice.number }}"
+                                                                        data-title="{{ 'invoice.details'|trans }}"
                                                                         class="text-decoration-none {{ invoice.status == 1 ? 'text-danger' : (invoice.status == 2 ? 'text-success' : (invoice.status == 3 ? 'text-warning' : 'text-muted')) }}"
                                                                         title="{{ ('invoice.status.' ~ (invoice.status == 1 ? 'unpaid' : invoice.status == 2 ? 'paid' : invoice.status == 3 ? 'prepaid' : 'canceled'))|trans }}">
                                                                             {{ invoice.number ? invoice.number : '–' }}

--- a/templates/Customers/customer_reservation_history.html.twig
+++ b/templates/Customers/customer_reservation_history.html.twig
@@ -1,4 +1,4 @@
-                <div class="row mt-3">
+                <div class="row">
                     <div class="col">
                         <div class="accordion accordion-flush" id="reservationHistoryAccordion">
                             <div class="accordion-item">
@@ -16,7 +16,7 @@
                                     class="accordion-collapse collapse"
                                     aria-labelledby="reservationHistoryHeading"
                                     data-bs-parent="#reservationHistoryAccordion">
-                                    <div class="accordion-body p-0">
+                                    <div class="accordion-body p-0 mt-3">
                                         {% if reservations is empty %}
                                             <p class="text-muted small p-3 mb-0">{{ 'customer.reservation.history.empty'|trans }}</p>
                                         {% else %}
@@ -35,7 +35,7 @@
                                                     </thead>
                                                     <tbody>
                                                         {% for res in reservations %}
-                                                        <tr class="{{ res.reservationStatus and res.reservationStatus.id == 3 ? 'text-muted' : '' }}">
+                                                        <tr class="{{ res.reservationStatus and res.reservationStatus.code == 'canceled_noshow' ? 'text-muted' : '' }}">
                                                             <td>{{ res.startDate|date('d.m.y') }}</td>
                                                             <td>{{ res.endDate|date('d.m.y') }}</td>
                                                             <td>{{ res.amount }}</td>

--- a/translations/Customers/messages.de.xlf
+++ b/translations/Customers/messages.de.xlf
@@ -214,6 +214,14 @@
                 <source>customer.mandateReference.label</source>
                 <target>Mandatsreferenznr.</target>
             </trans-unit>
+            <trans-unit id="customer.reservation.history">
+                <source>customer.reservation.history</source>
+                <target>Reservierungshistorie</target>
+            </trans-unit>
+            <trans-unit id="customer.reservation.history.empty">
+                <source>customer.reservation.history.empty</source>
+                <target>Keine Reservierungen vorhanden.</target>
+            </trans-unit>       
         </body>
     </file>
 </xliff>

--- a/translations/Customers/messages.en.yaml
+++ b/translations/Customers/messages.en.yaml
@@ -59,3 +59,5 @@ customer.accountIBAN.label: IBAN
 customer.accountIBAN.hint: >-
   The IBAN and mandate reference number must be filled in for the direct debit payment method.
 customer.mandateReference.label: Mandate Reference Number
+customer.reservation.history: "Reservation history"
+customer.reservation.history.empty: "No reservations found."


### PR DESCRIPTION
Hi,

auch daran hab ich mich versucht und ist denk ich gut geworden 😎
https://github.com/developeregrem/fewohbee/discussions/227#discussion-10086702

> - Schnellübersicht aller Reservierungen eines Gasts direkt in Fewohbee ermöglichen?  🚧
>   - Aktuell nur indirekt über DSGVO-Export möglich.

- Add loadAllReservationsForCustomer() to ReservationRepository covers booker and guest role, ordered by startDate DESC
- Inject ReservationRepository into getCustomerAction
- Display reservation history accordion in customer_form_show modal with dates, nights, apartment, reservation status, invoice number with color-coded payment status and direct link to reservation modal

<img width="793" height="897" alt="Bildschirmfoto vom 2026-06-05 13-10-05" src="https://github.com/user-attachments/assets/143e2c1d-6678-4931-bd5c-a0fdc50eb705" />
