### PR TITLE
Expand recurring calendar entries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "league/flysystem-aws-s3-v3": "^3",
         "mpdf/mpdf": "^8.2",
         "oneup/flysystem-bundle": "*",
+        "sabre/vobject": "^5.0",
         "symfony/asset": "8.1.*",
         "symfony/asset-mapper": "8.1.*",
         "symfony/console": "8.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc8d74a2b166959a6561ea207ecbabd1",
+    "content-hash": "c283de58ad4dbe259c1b18090d17aac1",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4003,6 +4003,249 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/uri.git",
+                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/a926c749dddfb289b8a9b5218d16ac06affdc631",
+                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "rector/rector": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/uri/issues",
+                "source": "https://github.com/fruux/sabre-uri"
+            },
+            "time": "2026-04-26T04:19:03+00:00"
+        },
+        {
+            "name": "sabre/vobject",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/vobject.git",
+                "reference": "2533eb0d67b2030e4f2bdacac972beb556d50e0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/2533eb0d67b2030e4f2bdacac972beb556d50e0d",
+                "reference": "2533eb0d67b2030e4f2bdacac972beb556d50e0d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^8.2",
+                "sabre/xml": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.2",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/php-invoker": "^5.0",
+                "phpunit/phpunit": "^11.5",
+                "rector/rector": "^2.4"
+            },
+            "suggest": {
+                "hoa/bench": "If you would like to run the benchmark scripts"
+            },
+            "bin": [
+                "bin/vobject",
+                "bin/generate_vcards"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\VObject\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dominik Tobschall",
+                    "email": "dominik@fruux.com",
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net",
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
+            "homepage": "http://sabre.io/vobject/",
+            "keywords": [
+                "availability",
+                "freebusy",
+                "iCalendar",
+                "ical",
+                "ics",
+                "jCal",
+                "jCard",
+                "recurrence",
+                "rfc2425",
+                "rfc2426",
+                "rfc2739",
+                "rfc4770",
+                "rfc5545",
+                "rfc5546",
+                "rfc6321",
+                "rfc6350",
+                "rfc6351",
+                "rfc6474",
+                "rfc6638",
+                "rfc6715",
+                "rfc6868",
+                "vCalendar",
+                "vCard",
+                "vcf",
+                "xCal",
+                "xCard"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/vobject/issues",
+                "source": "https://github.com/fruux/sabre-vobject"
+            },
+            "time": "2026-07-07T03:29:53+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/xml.git",
+                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
+                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": "^8.2",
+                "sabre/uri": ">=2.0,<4.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "rector/rector": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/xml/issues",
+                "source": "https://github.com/fruux/sabre-xml"
+            },
+            "time": "2026-04-27T10:56:01+00:00"
         },
         {
             "name": "setasign/fpdf",
@@ -12866,7 +13109,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -12874,6 +13117,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Command/CalendarEntrySyncCommand.php
+++ b/src/Command/CalendarEntrySyncCommand.php
@@ -49,14 +49,14 @@ class CalendarEntrySyncCommand extends Command
                     $result->unchanged,
                 ));
 
-                // Not a failure - the run stays successful - but silently
-                // importing nothing from a recurring feed is what makes this
-                // confusing in the first place, so it gets said out loud.
-                if ($result->skippedRecurring > 0) {
+                // Not a failure - the run stays successful - but an event the
+                // import quietly dropped looks like the calendar lost it, so
+                // it gets said out loud.
+                if ($result->skippedInvalid > 0) {
                     $io->warning(sprintf(
-                        '%s: %d recurring event(s) skipped, RRULE is not expanded.',
+                        '%s: %d event(s) skipped, their dates could not be read.',
                         $calendar->getName(),
-                        $result->skippedRecurring,
+                        $result->skippedInvalid,
                     ));
                 }
             } catch (CalendarSyncException $e) {

--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -95,18 +95,12 @@ class CalendarController extends AbstractController
                             '%updated%' => $result->updated,
                             '%unchanged%' => $result->unchanged,
                         ]));
-                    } elseif (0 === $result->skippedRecurring && 0 === $result->skippedInvalid) {
+                    } elseif (0 === $result->skippedInvalid) {
                         // Only claim the source was empty when it really was:
-                        // a feed made entirely of recurring or unreadable
-                        // events imports nothing either, and the messages
-                        // below name that reason instead of blaming the source.
+                        // a feed made entirely of unreadable events imports
+                        // nothing either, and the message below names that
+                        // reason instead of blaming the source.
                         $this->addFlash('warning', 'calendar.flash.synced_empty');
-                    }
-
-                    if ($result->skippedRecurring > 0) {
-                        $this->addFlash('warning', $translator->trans('calendar.flash.synced_recurring_skipped', [
-                            '%count%' => $result->skippedRecurring,
-                        ]));
                     }
 
                     if ($result->skippedInvalid > 0) {

--- a/src/Dto/Ics/IcsOccurrence.php
+++ b/src/Dto/Ics/IcsOccurrence.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto\Ics;
+
+/**
+ * One occurrence of a VEVENT, already resolved against the calendar's time
+ * zone and with any RRULE expanded into a separate instance.
+ *
+ * Produced by IcsOccurrenceReader and consumed by IcsEventSpanResolver. It
+ * exists so the day arithmetic downstream sees plain values instead of the
+ * parsing library's own types, which keeps that logic - and its tests -
+ * independent of which library reads the feed.
+ */
+final readonly class IcsOccurrence
+{
+    /**
+     * @param string              $uid     the source VEVENT's UID, empty when the feed omits it
+     * @param string              $summary SUMMARY, untrimmed and unbounded; the caller enforces column widths
+     * @param \DateTimeImmutable  $start   DTSTART of this occurrence, expressed in the target zone
+     * @param ?\DateTimeImmutable $end     DTEND of this occurrence in the target zone, null when the feed states none
+     * @param bool                $allDay  true when DTSTART is a date without a time (VALUE=DATE)
+     */
+    public function __construct(
+        public string $uid,
+        public string $summary,
+        public \DateTimeImmutable $start,
+        public ?\DateTimeImmutable $end,
+        public bool $allDay,
+    ) {
+    }
+}

--- a/src/Dto/Ics/IcsReadResult.php
+++ b/src/Dto/Ics/IcsReadResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto\Ics;
+
+/**
+ * What one pass over an ICS feed yielded: the occurrences inside the caller's
+ * window, and how many events had to be dropped along the way.
+ *
+ * The count travels with the occurrences so the sync can tell the user that a
+ * feed was read but parts of it were unusable, instead of reporting a clean
+ * run over a feed that half failed.
+ */
+final readonly class IcsReadResult
+{
+    /**
+     * @param list<IcsOccurrence> $occurrences ascending per event, not globally sorted
+     * @param int                 $skipped     VEVENTs whose recurrence could not be evaluated
+     */
+    public function __construct(
+        public array $occurrences,
+        public int $skipped,
+    ) {
+    }
+}

--- a/src/Service/CalendarEntrySyncResult.php
+++ b/src/Service/CalendarEntrySyncResult.php
@@ -7,23 +7,18 @@ namespace App\Service;
 final readonly class CalendarEntrySyncResult
 {
     /**
-     * @param int $skippedRecurring VEVENTs carrying an RRULE, which this import
-     *                              does not expand (see CalendarEntrySyncService).
-     *                              Counted separately so the caller can say so
-     *                              instead of leaving the user with a feed that
-     *                              silently produced nothing.
-     * @param int $skippedInvalid   VEVENTs whose period could not be read - no
-     *                              DTSTART, a DTEND not after it, or a span
-     *                              beyond IcsEventSpanResolver::MAX_EVENT_SPAN_DAYS.
-     *                              Counted for the same reason: a discarded
-     *                              event the user is never told about looks
-     *                              like the calendar lost it.
+     * @param int $skippedInvalid VEVENTs that could not be used - a DTEND not
+     *                            after DTSTART, a span beyond
+     *                            IcsEventSpanResolver::MAX_EVENT_SPAN_DAYS, or
+     *                            a recurrence rule the reader could not
+     *                            evaluate. Counted rather than swallowed: a
+     *                            discarded event the user is never told about
+     *                            looks like the calendar lost it.
      */
     public function __construct(
         public int $new,
         public int $updated,
         public int $unchanged,
-        public int $skippedRecurring = 0,
         public int $skippedInvalid = 0,
     ) {
     }

--- a/src/Service/CalendarEntrySyncService.php
+++ b/src/Service/CalendarEntrySyncService.php
@@ -8,9 +8,10 @@ use App\Entity\Calendar;
 use App\Entity\CalendarEntry;
 use App\Repository\CalendarEntryRepository;
 use App\Service\Exception\CalendarSyncException;
-use App\Service\Ics\IcsEventParser;
 use App\Service\Ics\IcsEventSpanResolver;
+use App\Service\Ics\IcsOccurrenceReader;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -23,15 +24,15 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * project's unrelated apartment-calendar export/subscription feature
  * (CalendarSync entity).
  *
- * Only single VEVENTs are supported (one per occurrence) - a source that
- * expresses its dates via an RRULE-recurring VEVENT isn't expanded. Such
- * events are skipped and counted, so the caller can tell the user why a
- * birthday or holiday feed produced nothing, rather than storing one entry
- * on the original DTSTART where it would never be seen.
+ * RRULE-recurring events are expanded into one entry per occurrence by
+ * IcsOccurrenceReader. Because such a rule can be unbounded, the import runs
+ * against a window: nothing is filed further ahead than EXPAND_YEARS_AHEAD,
+ * and nothing is filed in the past at all - see reconcile() for why entries
+ * that have merely aged into the past are nevertheless kept.
  *
- * Events whose period cannot be read at all (see IcsEventSpanResolver) are
- * discarded and counted the same way - a feed is untrusted input, and a
- * guessed date is worse than a reported skip.
+ * Events whose period cannot be read (see IcsEventSpanResolver) or whose
+ * recurrence cannot be evaluated are discarded and counted - a feed is
+ * untrusted input, and a guessed date is worse than a reported skip.
  */
 class CalendarEntrySyncService
 {
@@ -49,12 +50,20 @@ class CalendarEntrySyncService
     private const MAX_TITLE_LENGTH = 100;
     private const MAX_SOURCE_UID_LENGTH = 255;
 
+    /**
+     * How far ahead a recurrence is materialised. An RRULE without UNTIL or
+     * COUNT never ends, so the rows have to stop somewhere; the window moves
+     * with every sync, which is what keeps a series topped up.
+     */
+    private const EXPAND_YEARS_AHEAD = 2;
+
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly CalendarEntryRepository $repo,
-        private readonly IcsEventParser $icsParser,
+        private readonly IcsOccurrenceReader $icsReader,
         private readonly HttpClientInterface $httpClient,
         private readonly IcsEventSpanResolver $spanResolver,
+        private readonly ClockInterface $clock,
     ) {
     }
 
@@ -87,14 +96,13 @@ class CalendarEntrySyncService
 
     public function importIcsString(Calendar $calendar, string $icsData): CalendarEntrySyncResult
     {
-        if (!$this->icsParser->isValidCalendar($icsData)) {
+        if (!$this->icsReader->isValidCalendar($icsData)) {
             throw new CalendarSyncException('ICS-Datei konnte nicht gelesen werden.');
         }
 
         $new = 0;
         $updated = 0;
         $unchanged = 0;
-        $skippedRecurring = 0;
         $skippedInvalid = 0;
 
         // The zone a feed's instants are expressed in for storage. It comes
@@ -104,28 +112,27 @@ class CalendarEntrySyncService
         $zone = new \DateTimeZone(date_default_timezone_get());
 
         try {
-            // Collect the whole feed first, grouped by source event, so each
-            // event is reconciled against the database once with all of its
-            // dates known - two VEVENTs sharing a UID (or a UID-less feed
-            // repeating a summary) then merge instead of fighting over the
-            // same rows.
+            $today = $this->clock->now()->setTimezone($zone)->setTime(0, 0);
+            $windowEnd = $today->modify('+'.self::EXPAND_YEARS_AHEAD.' years');
+
+            // From today, not from the feed's own beginning: an occurrence
+            // entirely in the past is not read at all, so it cannot create a
+            // row. One still running is - fastForward() goes by the end - so a
+            // multi-day event keeps the days it has left.
+            $read = $this->icsReader->read($icsData, $zone, $today, $windowEnd);
+            $skippedInvalid += $read->skipped;
+
+            // Collected grouped by source event, so each event is reconciled
+            // against the database once with all of its dates known - two
+            // VEVENTs sharing a UID (or a UID-less feed repeating a summary)
+            // then merge instead of fighting over the same rows.
             $occurrences = [];
-            foreach ($this->icsParser->parseEvents($icsData) as $event) {
-                $summary = trim((string) ($event['SUMMARY'] ?? ''));
+            foreach ($read->occurrences as $occurrence) {
+                $summary = trim($occurrence->summary);
                 if ('' === $summary) {
                     continue;
                 }
 
-                // A recurring event carries its repetition in the RRULE, which
-                // is not expanded here. Importing it anyway would store a
-                // single entry on DTSTART - for a birthday feed that is the
-                // year of birth, decades in the past, where nobody will ever
-                // see it while the import cheerfully reports success. Skipped
-                // and counted instead, so the caller can name the reason.
-                if ('' !== trim((string) ($event['RRULE'] ?? ''))) {
-                    ++$skippedRecurring;
-                    continue;
-                }
                 // Truncated here rather than at the assignment sites so the
                 // stored title and the value hashed into a UID-less feed's
                 // source id stay the same string - otherwise a re-import
@@ -137,14 +144,14 @@ class CalendarEntrySyncService
                 // filed under a guessed day, and counted so the caller can
                 // say so instead of leaving the user with entries that
                 // silently never appeared.
-                $span = $this->spanResolver->resolve($event, $zone);
+                $span = $this->spanResolver->resolve($occurrence);
                 if (null === $span || [] === $span->dates) {
                     ++$skippedInvalid;
                     continue;
                 }
                 $lastIndex = array_key_last($span->dates);
 
-                $sourceUid = $this->buildSourceUid($calendar, $event, $summary, $span->dates[0]);
+                $sourceUid = $this->buildSourceUid($calendar, $occurrence->uid, $summary, $span->dates[0]);
                 $occurrences[$sourceUid] ??= ['summary' => $summary, 'dates' => [], 'times' => [], 'endTimes' => []];
                 $occurrences[$sourceUid]['summary'] = $summary;
 
@@ -168,8 +175,8 @@ class CalendarEntrySyncService
                 }
             }
 
-            foreach ($occurrences as $sourceUid => $occurrence) {
-                foreach ($this->reconcile($calendar, $sourceUid, $occurrence['summary'], $occurrence['dates'], $occurrence['times'], $occurrence['endTimes']) as $outcome) {
+            foreach ($occurrences as $sourceUid => $grouped) {
+                foreach ($this->reconcile($calendar, $sourceUid, $grouped['summary'], $grouped['dates'], $grouped['times'], $grouped['endTimes'], $today) as $outcome) {
                     match ($outcome) {
                         self::OUTCOME_NEW => $new++,
                         self::OUTCOME_UPDATED => $updated++,
@@ -178,7 +185,7 @@ class CalendarEntrySyncService
                 }
             }
 
-            $result = new CalendarEntrySyncResult($new, $updated, $unchanged, $skippedRecurring, $skippedInvalid);
+            $result = new CalendarEntrySyncResult($new, $updated, $unchanged, $skippedInvalid);
 
             // Recorded here (not by callers) so both the admin-form save path
             // and the calendars:sync cron command keep this in sync consistently.
@@ -224,12 +231,10 @@ class CalendarEntrySyncService
      * no way to tell a moved occurrence from an unrelated one, and the
      * date-independent identity below would then make every occurrence of a
      * repeating summary look like one event whose dates keep changing.
-     *
-     * @param array<string, string> $event
      */
-    private function buildSourceUid(Calendar $calendar, array $event, string $summary, \DateTimeImmutable $start): string
+    private function buildSourceUid(Calendar $calendar, string $rawUid, string $summary, \DateTimeImmutable $start): string
     {
-        $rawUid = trim((string) ($event['UID'] ?? ''));
+        $rawUid = trim($rawUid);
         $suffix = '' !== $rawUid ? $rawUid : md5($summary.'-'.$start->format('Ymd'));
 
         $sourceUid = 'cal'.$calendar->getId().'-'.$suffix;
@@ -266,14 +271,33 @@ class CalendarEntrySyncService
      *
      * @return list<string> one OUTCOME_* per entry touched or left in place
      */
-    private function reconcile(Calendar $calendar, string $sourceUid, string $summary, array $dates, array $times = [], array $endTimes = []): array
+    private function reconcile(Calendar $calendar, string $sourceUid, string $summary, array $dates, array $times, array $endTimes, \DateTimeImmutable $today): array
     {
         ksort($dates);
         $existing = $this->repo->findBySource($calendar, $sourceUid);
 
+        // Nothing is filed behind today. A still-running multi-day event is
+        // read whole - it has to be, or its remaining days would be lost - so
+        // the days of it that have passed are dropped here rather than turned
+        // into rows nobody asked for.
+        foreach ($dates as $dateKey => $date) {
+            if ($date < $today) {
+                unset($dates[$dateKey], $times[$dateKey], $endTimes[$dateKey]);
+            }
+        }
+
         $matched = [];
         $spare = [];
         foreach ($existing as $entry) {
+            // A row for a day that has passed is left alone entirely: neither
+            // matched, nor reused for another date, nor removed. It was filed
+            // when it was still ahead, and clearing it out is the user's
+            // decision through deleteUnconfirmedPast() - not something a sync
+            // does behind their back an hour later.
+            if ($entry->getDate() < $today) {
+                continue;
+            }
+
             $key = $entry->getDate()->format('Y-m-d');
             if (isset($dates[$key]) && !isset($matched[$key])) {
                 $matched[$key] = $entry;

--- a/src/Service/CalendarEntrySyncService.php
+++ b/src/Service/CalendarEntrySyncService.php
@@ -152,8 +152,7 @@ class CalendarEntrySyncService
                 $lastIndex = array_key_last($span->dates);
 
                 $sourceUid = $this->buildSourceUid($calendar, $occurrence->uid, $summary, $span->dates[0]);
-                $occurrences[$sourceUid] ??= ['summary' => $summary, 'dates' => [], 'times' => [], 'endTimes' => []];
-                $occurrences[$sourceUid]['summary'] = $summary;
+                $occurrences[$sourceUid] ??= ['dates' => [], 'summaries' => [], 'times' => [], 'endTimes' => []];
 
                 // What earlier VEVENTs sharing this UID already recorded. Read
                 // out first so the loop below can fall back to it: a later
@@ -165,6 +164,10 @@ class CalendarEntrySyncService
                 foreach ($span->dates as $index => $date) {
                     $dateKey = $date->format('Y-m-d');
                     $occurrences[$sourceUid]['dates'][$dateKey] = $date;
+                    // Per date, not per event: a RECURRENCE-ID override is a second
+                    // VEVENT under the same UID carrying its own SUMMARY, and the day
+                    // it moved to has to read as that one rather than as the series.
+                    $occurrences[$sourceUid]['summaries'][$dateKey] = $summary;
                     // The day the event starts on carries the start time and
                     // the day it ends on the end time; the days in between run
                     // all day by definition.
@@ -176,7 +179,7 @@ class CalendarEntrySyncService
             }
 
             foreach ($occurrences as $sourceUid => $grouped) {
-                foreach ($this->reconcile($calendar, $sourceUid, $grouped['summary'], $grouped['dates'], $grouped['times'], $grouped['endTimes'], $today) as $outcome) {
+                foreach ($this->reconcile($calendar, $sourceUid, $grouped['summaries'], $grouped['dates'], $grouped['times'], $grouped['endTimes'], $today) as $outcome) {
                     match ($outcome) {
                         self::OUTCOME_NEW => $new++,
                         self::OUTCOME_UPDATED => $updated++,
@@ -265,13 +268,16 @@ class CalendarEntrySyncService
      * date keeps it, one whose date is gone is left alone rather than being
      * reused for another day.
      *
+     * @param array<string, string>              $summaries keyed by Y-m-d; a moved occurrence
+     *                                                      carries its own title, so this is
+     *                                                      per date rather than per event
      * @param array<string, \DateTimeImmutable>  $dates    keyed by Y-m-d
      * @param array<string, ?\DateTimeImmutable> $times    keyed by Y-m-d, null where the day has no start time
      * @param array<string, ?\DateTimeImmutable> $endTimes keyed by Y-m-d, null where the day has no end time
      *
      * @return list<string> one OUTCOME_* per entry touched or left in place
      */
-    private function reconcile(Calendar $calendar, string $sourceUid, string $summary, array $dates, array $times, array $endTimes, \DateTimeImmutable $today): array
+    private function reconcile(Calendar $calendar, string $sourceUid, array $summaries, array $dates, array $times, array $endTimes, \DateTimeImmutable $today): array
     {
         ksort($dates);
         $existing = $this->repo->findBySource($calendar, $sourceUid);
@@ -282,7 +288,7 @@ class CalendarEntrySyncService
         // into rows nobody asked for.
         foreach ($dates as $dateKey => $date) {
             if ($date < $today) {
-                unset($dates[$dateKey], $times[$dateKey], $endTimes[$dateKey]);
+                unset($dates[$dateKey], $summaries[$dateKey], $times[$dateKey], $endTimes[$dateKey]);
             }
         }
 
@@ -308,6 +314,7 @@ class CalendarEntrySyncService
 
         $outcomes = [];
         foreach ($matched as $dateKey => $entry) {
+            $summary = $summaries[$dateKey] ?? '';
             $time = $times[$dateKey] ?? null;
             $endTime = $endTimes[$dateKey] ?? null;
             if ($entry->isConfirmed()
@@ -323,6 +330,7 @@ class CalendarEntrySyncService
         }
 
         foreach (array_diff_key($dates, $matched) as $dateKey => $date) {
+            $summary = $summaries[$dateKey] ?? '';
             $time = $times[$dateKey] ?? null;
             $endTime = $endTimes[$dateKey] ?? null;
             $entry = $this->takeReusable($spare);

--- a/src/Service/Ics/IcsEventParser.php
+++ b/src/Service/Ics/IcsEventParser.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Service\Ics;
 
 /**
- * Minimal ICS (RFC 5545) reader shared by every feature that consumes an
- * external calendar feed (channel-manager reservation sync, configurable
- * calendars). Deliberately doesn't expand RRULE-recurring events - the
- * source feed is expected to list one VEVENT per occurrence.
+ * Minimal ICS (RFC 5545) reader, still used by the channel-manager reservation
+ * sync in CalendarImportService. It reads flat property values only: no
+ * recurrence, and no time zone - a TZID parameter is ignored, which is
+ * harmless for the VALUE=DATE feeds that path sees and wrong for any other.
+ *
+ * Configurable calendars moved to IcsOccurrenceReader, which does both. This
+ * class disappears once the reservation sync follows.
  */
 class IcsEventParser
 {
@@ -16,17 +19,6 @@ class IcsEventParser
     {
         return str_contains($content, 'BEGIN:VCALENDAR') && str_contains($content, 'END:VCALENDAR');
     }
-
-    /**
-     * Suffix under which a property's parameters are kept alongside its value,
-     * e.g. DTSTART;TZID=Europe/Berlin:20260814T130000 yields both
-     * `DTSTART` => '20260814T130000' and `DTSTART;PARAMS` => 'TZID=Europe/Berlin'.
-     *
-     * Stored under a separate key rather than changing the shape of the value
-     * so consumers that only ever want the value (CalendarImportService) keep
-     * reading it unchanged.
-     */
-    public const PARAMS_SUFFIX = ';PARAMS';
 
     /**
      * @return array<int, array<string, string>> flat property => value maps, one per VEVENT
@@ -72,9 +64,6 @@ class IcsEventParser
             $nameParts = explode(';', $name, 2);
             $name = strtoupper($nameParts[0]);
             $current[$name] = $value;
-            if (isset($nameParts[1]) && '' !== $nameParts[1]) {
-                $current[$name.self::PARAMS_SUFFIX] = $nameParts[1];
-            }
         }
 
         return $events;
@@ -91,66 +80,6 @@ class IcsEventParser
 
         try {
             return new \DateTimeImmutable($value);
-        } catch (\Exception $exception) {
-            return null;
-        }
-    }
-
-    /** Whether a property value is a bare date (VALUE=DATE), i.e. an all-day one. */
-    public function isDateOnly(string $value): bool
-    {
-        return 1 === preg_match('/^\d{8}$/', $value);
-    }
-
-    /**
-     * Parses a date-time property into the instant it actually denotes, then
-     * expresses it in $display.
-     *
-     * RFC 5545 knows three forms, and only the first was handled correctly
-     * before: a trailing Z is UTC, a TZID parameter names the zone, and a bare
-     * value is "floating" local time. Reading a UTC value and then showing its
-     * UTC digits is what made a 13:00 event from a Google feed appear as 11:00.
-     *
-     * @param string $params the property's raw parameter string, if any
-     */
-    public function parseDateTimeInZone(string $value, ?string $params, \DateTimeZone $display): ?\DateTimeImmutable
-    {
-        if ($this->isDateOnly($value)) {
-            $date = \DateTimeImmutable::createFromFormat('!Ymd', $value, $display);
-
-            return $date ?: null;
-        }
-
-        // A trailing Z carries its own zone, so a TZID alongside it is ignored
-        // (and would be invalid per RFC 5545 anyway).
-        $zone = $display;
-        if (!str_ends_with($value, 'Z')) {
-            $tzid = $this->extractTzid($params);
-            if (null !== $tzid) {
-                $zone = $tzid;
-            }
-        }
-
-        try {
-            return (new \DateTimeImmutable($value, $zone))->setTimezone($display);
-        } catch (\Exception $exception) {
-            return null;
-        }
-    }
-
-    /**
-     * The zone named by a TZID parameter, or null when absent or unknown to
-     * PHP - an unrecognised zone falls back to the caller's display zone
-     * rather than dropping the event.
-     */
-    private function extractTzid(?string $params): ?\DateTimeZone
-    {
-        if (null === $params || 1 !== preg_match('/(?:^|;)TZID=([^;]+)/i', $params, $matches)) {
-            return null;
-        }
-
-        try {
-            return new \DateTimeZone(trim($matches[1], '"'));
         } catch (\Exception $exception) {
             return null;
         }

--- a/src/Service/Ics/IcsEventSpanResolver.php
+++ b/src/Service/Ics/IcsEventSpanResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Ics;
 
 use App\Dto\Ics\IcsEventSpan;
+use App\Dto\Ics\IcsOccurrence;
 use App\Service\CalendarEntryTimeRules;
 
 /**
@@ -33,60 +34,36 @@ final class IcsEventSpanResolver
     public const MAX_EVENT_SPAN_DAYS = 366;
 
     public function __construct(
-        private readonly IcsEventParser $parser,
         private readonly CalendarEntryTimeRules $timeRules,
     ) {
     }
 
     /**
-     * Resolves a VEVENT property map, or returns null when the event is not
-     * usable and must be discarded.
+     * Resolves one occurrence, or returns null when it is not usable and must
+     * be discarded.
      *
-     * Everything is resolved in $zone first, because the zone decides the
-     * calendar day as much as the clock time: a feed's 20260814T230000Z is the
-     * 15th in Europe/Berlin, not the 14th.
+     * The occurrence already carries its instants in the target zone, because
+     * the zone decides the calendar day as much as the clock time: a feed's
+     * 20260814T230000Z is the 15th in Europe/Berlin, not the 14th.
      *
      * Discarded (null) when:
-     * - DTSTART is missing or unparseable - there is no day to file it under;
      * - DTEND is not after DTSTART - RFC 5545 requires it to be later, so such
      *   an event carries no usable period. A same-value DTEND is rejected too:
      *   feeds write it both for a zero-length event and, wrongly, for a
      *   single all-day one, and guessing which was meant would silently
      *   invent a day the source never stated;
      * - the span exceeds MAX_EVENT_SPAN_DAYS.
-     *
-     * @param array<string, string> $event flat property => value map, as produced by IcsEventParser
      */
-    public function resolve(array $event, \DateTimeZone $zone): ?IcsEventSpan
+    public function resolve(IcsOccurrence $occurrence): ?IcsEventSpan
     {
-        $dtStartRaw = $event['DTSTART'] ?? null;
-        if (null === $dtStartRaw) {
-            return null;
-        }
+        $allDay = $occurrence->allDay;
 
-        $allDay = $this->parser->isDateOnly($dtStartRaw);
-
-        $start = $this->parser->parseDateTimeInZone($dtStartRaw, $event['DTSTART'.IcsEventParser::PARAMS_SUFFIX] ?? null, $zone);
-        if (null === $start) {
-            return null;
-        }
         // Normalised before anything compares them, so the checks below, the
         // day loop and the stored value all work on the same resolution.
-        $start = $this->toWholeMinutes($start);
+        $start = $this->toWholeMinutes($occurrence->start);
         $startDay = $start->setTime(0, 0);
 
-        $dtEndRaw = $event['DTEND'] ?? null;
-        $end = null !== $dtEndRaw
-            ? $this->parser->parseDateTimeInZone($dtEndRaw, $event['DTEND'.IcsEventParser::PARAMS_SUFFIX] ?? null, $zone)
-            : null;
-
-        // An unparseable DTEND is not the same as an absent one: the event did
-        // state a period and we failed to read it, so filing it as a single
-        // day would put a made-up period in the calendar.
-        if (null !== $dtEndRaw && null === $end) {
-            return null;
-        }
-        $end = null !== $end ? $this->toWholeMinutes($end) : null;
+        $end = null !== $occurrence->end ? $this->toWholeMinutes($occurrence->end) : null;
         // Checked after normalising, so an event shorter than a minute counts
         // as the zero-length period it becomes rather than slipping through
         // on seconds the rest of the application cannot represent.

--- a/src/Service/Ics/IcsOccurrenceReader.php
+++ b/src/Service/Ics/IcsOccurrenceReader.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Ics;
+
+use App\Dto\Ics\IcsOccurrence;
+use App\Dto\Ics\IcsReadResult;
+use Sabre\VObject\Property\ICalendar\DateTime as DateTimeProperty;
+use Sabre\VObject\Reader;
+use Sabre\VObject\Recur\EventIterator;
+
+/**
+ * Reads an ICS feed into plain occurrences, expanding RRULE-recurring events
+ * into one instance per date.
+ *
+ * Built on sabre/vobject's EventIterator rather than VCalendar::expand():
+ * expand() rewrites every instant into the zone passed to it (UTC by default)
+ * and fails for the whole calendar when a single event carries an unusable
+ * recurrence, while the iterator works per event, so one broken VEVENT is
+ * discarded and counted while the rest of the feed still imports.
+ */
+class IcsOccurrenceReader
+{
+    /**
+     * Upper bound on the instances one VEVENT may contribute, independent of
+     * the caller's window. A feed is untrusted input, and a rule such as
+     * FREQ=HOURLY would otherwise fill a two-year window with some seventeen
+     * thousand rows. An event that exceeds this is discarded whole and
+     * counted, not cut off partway. Two years of daily occurrences - 731 -
+     * stay below it, so only rules finer than daily are affected.
+     */
+    public const MAX_OCCURRENCES_PER_EVENT = 1000;
+
+    public function isValidCalendar(string $content): bool
+    {
+        return str_contains($content, 'BEGIN:VCALENDAR') && str_contains($content, 'END:VCALENDAR');
+    }
+
+    /**
+     * Every occurrence starting inside [$from, $to), expressed in $zone.
+     *
+     * The window is half-open at the top so a recurrence landing exactly on
+     * $to belongs to the next window rather than to both.
+     *
+     * @throws \Sabre\VObject\ParseException when the feed is structurally unreadable
+     */
+    public function read(string $content, \DateTimeZone $zone, \DateTimeImmutable $from, \DateTimeImmutable $to): IcsReadResult
+    {
+        $calendar = Reader::read($content, Reader::OPTION_FORGIVING);
+
+        // Grouped by UID because a recurring event and its RECURRENCE-ID
+        // overrides are separate VEVENTs that only together describe the
+        // series - the iterator needs all of them at once to place a moved
+        // occurrence on its new time instead of its original one.
+        $groups = [];
+        $withoutUid = [];
+        foreach ($calendar->VEVENT ?? [] as $event) {
+            $uid = trim((string) ($event->UID ?? ''));
+            if ('' === $uid) {
+                $withoutUid[] = $event;
+                continue;
+            }
+            $groups[$uid] = true;
+        }
+
+        $occurrences = [];
+        $skipped = 0;
+
+        foreach (array_keys($groups) as $uid) {
+            try {
+                $iterator = new EventIterator($calendar, (string) $uid, $zone);
+            } catch (\Throwable $exception) {
+                // An unusable RRULE, or a UID whose only VEVENT is an orphaned
+                // override. Counted rather than thrown so the feed's remaining
+                // events still import.
+                ++$skipped;
+                continue;
+            }
+
+            $this->collect($iterator, (string) $uid, $zone, $from, $to, $occurrences, $skipped);
+        }
+
+        // A feed without UIDs is invalid per RFC 5545 but occurs in the wild.
+        // Each such VEVENT stands alone: it cannot carry overrides, and it
+        // must not be merged with the others into one nameless series.
+        foreach ($withoutUid as $event) {
+            try {
+                $iterator = new EventIterator([$event], null, $zone);
+            } catch (\Throwable $exception) {
+                ++$skipped;
+                continue;
+            }
+
+            $this->collect($iterator, '', $zone, $from, $to, $occurrences, $skipped);
+        }
+
+        return new IcsReadResult($occurrences, $skipped);
+    }
+
+    /**
+     * @param list<IcsOccurrence> $occurrences
+     */
+    private function collect(
+        EventIterator $iterator,
+        string $uid,
+        \DateTimeZone $zone,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        array &$occurrences,
+        int &$skipped,
+    ): void {
+        // Buffered per event so an event that turns out to exceed the cap can
+        // be dropped whole. Handing over the first thousand of a runaway rule
+        // would fill the calendar with rows nobody can tell apart from real
+        // ones, and say nothing about it.
+        $collected = [];
+
+        try {
+            $iterator->fastForward($from);
+
+            while ($iterator->valid() && $iterator->getDtStart() < $to) {
+                $event = $iterator->getEventObject();
+
+                // Only an end the source actually stated is passed on. With
+                // neither DTEND nor DURATION the iterator reports an end equal
+                // to the start, which is indistinguishable from a feed writing
+                // DTEND == DTSTART - and that one has to stay rejected, since
+                // it is written both for a zero-length event and, wrongly, for
+                // a single all-day one.
+                $statesEnd = [] !== $event->select('DTEND') || [] !== $event->select('DURATION');
+
+                // A DTSTART without a clock time (VALUE=DATE) marks an all-day
+                // occurrence; the property class is what distinguishes the two.
+                $dtStart = $event->select('DTSTART')[0] ?? null;
+
+                // setTimezone is not optional: the iterator yields each instant
+                // in the zone the source expressed it in, and the zone handed
+                // to its constructor only fills in for floating times. Without
+                // this a feed's 20260814T230000Z stays 23:00 UTC and would be
+                // filed on the 14th instead of the 15th in Berlin.
+                $collected[] = new IcsOccurrence(
+                    uid: $uid,
+                    summary: (string) ($event->SUMMARY ?? ''),
+                    start: $iterator->getDtStart()->setTimezone($zone),
+                    end: $statesEnd ? $iterator->getDtEnd()?->setTimezone($zone) : null,
+                    allDay: !($dtStart instanceof DateTimeProperty && $dtStart->hasTime()),
+                );
+
+                if (\count($collected) > self::MAX_OCCURRENCES_PER_EVENT) {
+                    ++$skipped;
+
+                    return;
+                }
+                $iterator->next();
+            }
+        } catch (\Throwable $exception) {
+            // Recurrence rules are evaluated lazily, so a rule that only turns
+            // out to be unusable partway through lands here rather than at
+            // construction. What it produced before failing is still good.
+            ++$skipped;
+        }
+
+        foreach ($collected as $occurrence) {
+            $occurrences[] = $occurrence;
+        }
+    }
+
+}

--- a/tests/Functional/CalendarEntrySyncServiceTest.php
+++ b/tests/Functional/CalendarEntrySyncServiceTest.php
@@ -819,6 +819,68 @@ final class CalendarEntrySyncServiceTest extends KernelTestCase
         self::assertSame('Restmüll', $titles['2026-09-07'] ?? null);
     }
 
+    /**
+     * The other way a series states an exception: EXDATE drops a single occurrence
+     * instead of moving it. Nothing may be filed on that day.
+     */
+    public function testAnExcludedOccurrenceIsNotImported(): void
+    {
+        $calendar = $this->createCalendar('Muell EXDATE '.uniqid());
+
+        $result = $this->service->importIcsString($calendar, $this->buildWeeklyMuellIcs(withExdate: true));
+
+        self::assertSame(0, $result->skippedInvalid);
+
+        $dates = array_map(
+            static fn (CalendarEntry $e) => $e->getDate()->format('Y-m-d'),
+            $this->entriesForCalendar($calendar),
+        );
+
+        self::assertNotContains('2026-08-31', $dates);
+        // The occurrences around it stay, so the whole series was not dropped by mistake.
+        self::assertContains('2026-08-24', $dates);
+        self::assertContains('2026-09-07', $dates);
+    }
+
+    /** A date that later disappears from the feed takes its unconfirmed entry with it. */
+    public function testAnOccurrenceExcludedLaterRemovesItsEntry(): void
+    {
+        $calendar = $this->createCalendar('Muell EXDATE spaeter '.uniqid());
+
+        $this->service->importIcsString($calendar, $this->buildWeeklyMuellIcs(withExdate: false));
+        self::assertContains('2026-08-31', array_map(
+            static fn (CalendarEntry $e) => $e->getDate()->format('Y-m-d'),
+            $this->entriesForCalendar($calendar),
+        ));
+
+        $this->service->importIcsString($calendar, $this->buildWeeklyMuellIcs(withExdate: true));
+
+        self::assertNotContains('2026-08-31', array_map(
+            static fn (CalendarEntry $e) => $e->getDate()->format('Y-m-d'),
+            $this->entriesForCalendar($calendar),
+        ));
+    }
+
+    private function buildWeeklyMuellIcs(bool $withExdate): string
+    {
+        $lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'BEGIN:VEVENT',
+            'UID:muellabfuhr-exdate',
+            'DTSTART;VALUE=DATE:20260803',
+            'RRULE:FREQ=WEEKLY;UNTIL=20260914',
+        ];
+        if ($withExdate) {
+            $lines[] = 'EXDATE;VALUE=DATE:20260831';
+        }
+        $lines[] = 'SUMMARY:Restmüll';
+        $lines[] = 'END:VEVENT';
+        $lines[] = 'END:VCALENDAR';
+
+        return implode("\r\n", $lines);
+    }
+
     private function createCalendar(string $name): Calendar
     {
         $calendar = new Calendar();

--- a/tests/Functional/CalendarEntrySyncServiceTest.php
+++ b/tests/Functional/CalendarEntrySyncServiceTest.php
@@ -775,6 +775,50 @@ final class CalendarEntrySyncServiceTest extends KernelTestCase
         self::assertNull($this->entriesForCalendar($calendar)[0]->getTime());
     }
 
+    /**
+     * A series with a single moved occurrence: the bin collection falls on a public
+     * holiday, so that one date carries its own SUMMARY. The override must keep its
+     * title instead of inheriting the series one.
+     */
+    public function testAMovedOccurrenceKeepsItsOwnTitle(): void
+    {
+        $calendar = $this->createCalendar('Muell '.uniqid());
+
+        $ics = implode("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'BEGIN:VEVENT',
+            'UID:muellabfuhr',
+            'DTSTART;VALUE=DATE:20260803',
+            'RRULE:FREQ=WEEKLY;UNTIL=20260914',
+            'SUMMARY:Restmüll',
+            'END:VEVENT',
+            'BEGIN:VEVENT',
+            'UID:muellabfuhr',
+            'RECURRENCE-ID;VALUE=DATE:20260831',
+            'DTSTART;VALUE=DATE:20260901',
+            'SUMMARY:Restmüll – wegen Feiertag',
+            'END:VEVENT',
+            'END:VCALENDAR',
+        ]);
+
+        $result = $this->service->importIcsString($calendar, $ics);
+        self::assertSame(0, $result->skippedInvalid);
+
+        $titles = [];
+        foreach ($this->entriesForCalendar($calendar) as $entry) {
+            $titles[$entry->getDate()->format('Y-m-d')] = $entry->getTitle();
+        }
+
+        // The moved occurrence sits on its new day under its own title,
+        self::assertSame('Restmüll – wegen Feiertag', $titles['2026-09-01'] ?? null);
+        // the original Monday is gone,
+        self::assertArrayNotHasKey('2026-08-31', $titles);
+        // and every other occurrence still reads as the series does.
+        self::assertSame('Restmüll', $titles['2026-08-24'] ?? null);
+        self::assertSame('Restmüll', $titles['2026-09-07'] ?? null);
+    }
+
     private function createCalendar(string $name): Calendar
     {
         $calendar = new Calendar();

--- a/tests/Functional/CalendarEntrySyncServiceTest.php
+++ b/tests/Functional/CalendarEntrySyncServiceTest.php
@@ -11,10 +11,20 @@ use App\Service\CalendarEntrySyncService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Clock\Test\ClockSensitiveTrait;
 
 /** Verify that CalendarEntrySyncService expands multi-day (DTSTART..DTEND) VEVENTs into one CalendarEntry per day. */
 final class CalendarEntrySyncServiceTest extends KernelTestCase
 {
+    use ClockSensitiveTrait;
+
+    /**
+     * The import files nothing behind the current day, so every fixed date in
+     * this file has to sit ahead of it. Pinning the clock keeps that true
+     * instead of letting these tests expire the moment real time passes them.
+     */
+    private const TODAY = '2025-12-01 09:00:00';
+
     private EntityManagerInterface $em;
     private CalendarEntrySyncService $service;
     private string $originalTimezone;
@@ -22,6 +32,7 @@ final class CalendarEntrySyncServiceTest extends KernelTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        self::mockTime(new \DateTimeImmutable(self::TODAY, new \DateTimeZone('Europe/Berlin')));
         self::bootKernel();
         $this->em = static::getContainer()->get(ManagerRegistry::class)->getManager();
         $this->service = static::getContainer()->get(CalendarEntrySyncService::class);
@@ -292,13 +303,13 @@ final class CalendarEntrySyncServiceTest extends KernelTestCase
         self::assertNotSame($entries[0]->getSourceUid(), $entries[1]->getSourceUid());
     }
 
-    public function testRecurringEventIsSkippedAndCountedInsteadOfLandingOnItsFirstDate(): void
+    public function testRecurringEventIsExpandedIntoOneEntryPerOccurrence(): void
     {
         $calendar = $this->createCalendar('Geburtstage '.uniqid());
 
         // How a birthday actually looks in an exported feed: one VEVENT on the
-        // year of birth, repeating via RRULE. Importing DTSTART alone would
-        // file it decades in the past, where nobody would ever see it.
+        // year of birth, repeating via RRULE. The entries have to land on the
+        // coming 15 March, not on the year of birth.
         $ics = implode("\r\n", [
             'BEGIN:VCALENDAR',
             'VERSION:2.0',
@@ -313,12 +324,17 @@ final class CalendarEntrySyncServiceTest extends KernelTestCase
 
         $result = $this->service->importIcsString($calendar, $ics);
 
-        self::assertSame(1, $result->skippedRecurring);
-        self::assertSame(0, $result->total());
-        self::assertCount(0, $this->entriesForCalendar($calendar));
+        self::assertSame(0, $result->skippedInvalid);
+
+        // Two years ahead of the pinned day, so 2026 and 2027 - and nothing
+        // from 1980, which is the whole point.
+        self::assertSame(['2026-03-15', '2027-03-15'], array_map(
+            static fn (CalendarEntry $e) => $e->getDate()->format('Y-m-d'),
+            $this->entriesForCalendar($calendar),
+        ));
     }
 
-    public function testANonRecurringEventInTheSameFeedStillImports(): void
+    public function testARecurringAndAPlainEventInOneFeedBothImport(): void
     {
         $calendar = $this->createCalendar('Gemischt '.uniqid());
 
@@ -341,18 +357,139 @@ final class CalendarEntrySyncServiceTest extends KernelTestCase
 
         $result = $this->service->importIcsString($calendar, $ics);
 
-        self::assertSame(1, $result->skippedRecurring);
-        self::assertSame(1, $result->new);
-        self::assertSame('Restmüll', $this->entriesForCalendar($calendar)[0]->getTitle());
+        self::assertSame(0, $result->skippedInvalid);
+
+        $titles = array_map(
+            static fn (CalendarEntry $e) => $e->getTitle(),
+            $this->entriesForCalendar($calendar),
+        );
+        self::assertContains('Restmüll', $titles);
+        self::assertContains('Geburtstag Anna', $titles);
     }
 
-    public function testAFeedWithoutRecurrenceReportsNothingSkipped(): void
+    public function testDatesAlreadyPastAreNotImported(): void
+    {
+        $calendar = $this->createCalendar('Vergangenes '.uniqid());
+
+        // One date behind the pinned day, one ahead of it, in the same feed.
+        $ics = implode("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'BEGIN:VEVENT',
+            'UID:schon-vorbei',
+            'DTSTART;VALUE=DATE:20251120',
+            'SUMMARY:Schon vorbei',
+            'END:VEVENT',
+            'BEGIN:VEVENT',
+            'UID:kommt-noch',
+            'DTSTART;VALUE=DATE:20251215',
+            'SUMMARY:Kommt noch',
+            'END:VEVENT',
+            'END:VCALENDAR',
+        ]);
+
+        $result = $this->service->importIcsString($calendar, $ics);
+
+        self::assertSame(1, $result->new);
+        self::assertSame(['Kommt noch'], array_map(
+            static fn (CalendarEntry $e) => $e->getTitle(),
+            $this->entriesForCalendar($calendar),
+        ));
+    }
+
+    public function testAMultiDayEventAlreadyRunningKeepsTheDaysItHasLeft(): void
+    {
+        $calendar = $this->createCalendar('Laufend '.uniqid());
+
+        // Started before the pinned day and still running. Reading it whole is
+        // what keeps its remaining days; only the days behind today drop out.
+        $ics = $this->buildIcs('urlaub', '20251129', '20251204', 'Urlaub');
+        $this->service->importIcsString($calendar, $ics);
+
+        self::assertSame(['2025-12-01', '2025-12-02', '2025-12-03'], array_map(
+            static fn (CalendarEntry $e) => $e->getDate()->format('Y-m-d'),
+            $this->entriesForCalendar($calendar),
+        ));
+    }
+
+    public function testAPastEntryOfAStillRunningSeriesIsLeftAlone(): void
+    {
+        $calendar = $this->createCalendar('Bestand '.uniqid());
+
+        // What an earlier sync left behind: a row for an occurrence that has
+        // since passed. The series still runs, so reconcile() does look at this
+        // source event - and has to leave the old row alone rather than reuse
+        // it for one of the coming dates. Removing it is the user's decision.
+        $entry = (new CalendarEntry())
+            ->setCalendar($calendar)
+            ->setSourceUid('cal'.$calendar->getId().'-woechentlich')
+            ->setDate(new \DateTimeImmutable('2025-11-24'))
+            ->setTitle('Restmüll');
+        $this->em->persist($entry);
+        $this->em->flush();
+
+        $ics = implode("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'BEGIN:VEVENT',
+            'UID:woechentlich',
+            'DTSTART;VALUE=DATE:20251124',
+            'RRULE:FREQ=WEEKLY;COUNT=6',
+            'SUMMARY:Restmüll',
+            'END:VEVENT',
+            'END:VCALENDAR',
+        ]);
+
+        $this->service->importIcsString($calendar, $ics);
+
+        $dates = array_map(
+            static fn (CalendarEntry $e) => $e->getDate()->format('Y-m-d'),
+            $this->entriesForCalendar($calendar),
+        );
+
+        // The stored 24 November survives, nothing new is filed behind today,
+        // and the remaining occurrences of the series are imported.
+        self::assertSame(['2025-11-24', '2025-12-01', '2025-12-08', '2025-12-15', '2025-12-22', '2025-12-29'], $dates);
+    }
+
+    public function testAnUnusableRecurrenceIsCountedWithoutLosingTheRestOfTheFeed(): void
+    {
+        $calendar = $this->createCalendar('Kaputte Regel '.uniqid());
+
+        $ics = implode("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'BEGIN:VEVENT',
+            'UID:unsinn',
+            'DTSTART;VALUE=DATE:20251215',
+            'RRULE:FREQ=BLUBB',
+            'SUMMARY:Unsinnige Regel',
+            'END:VEVENT',
+            'BEGIN:VEVENT',
+            'UID:heil',
+            'DTSTART;VALUE=DATE:20251216',
+            'SUMMARY:Heiler Termin',
+            'END:VEVENT',
+            'END:VCALENDAR',
+        ]);
+
+        $result = $this->service->importIcsString($calendar, $ics);
+
+        self::assertSame(1, $result->skippedInvalid);
+        self::assertSame(1, $result->new);
+        self::assertSame(['Heiler Termin'], array_map(
+            static fn (CalendarEntry $e) => $e->getTitle(),
+            $this->entriesForCalendar($calendar),
+        ));
+    }
+
+    public function testAReadableFeedReportsNothingSkipped(): void
     {
         $calendar = $this->createCalendar('Ohne Serie '.uniqid());
 
         $result = $this->service->importIcsString($calendar, $this->buildIcs('uid-plain', '20260911', null, 'Papier'));
 
-        self::assertSame(0, $result->skippedRecurring);
+        self::assertSame(0, $result->skippedInvalid);
         self::assertSame(1, $result->new);
     }
 

--- a/tests/Unit/IcsEventSpanResolverTest.php
+++ b/tests/Unit/IcsEventSpanResolverTest.php
@@ -4,19 +4,22 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit;
 
+use App\Dto\Ics\IcsOccurrence;
 use App\Service\CalendarEntryTimeRules;
-use App\Service\Ics\IcsEventParser;
 use App\Service\Ics\IcsEventSpanResolver;
+use App\Service\Ics\IcsOccurrenceReader;
 use PHPUnit\Framework\TestCase;
 
 final class IcsEventSpanResolverTest extends TestCase
 {
     private IcsEventSpanResolver $resolver;
+    private IcsOccurrenceReader $reader;
     private \DateTimeZone $berlin;
 
     protected function setUp(): void
     {
-        $this->resolver = new IcsEventSpanResolver(new IcsEventParser(), new CalendarEntryTimeRules());
+        $this->resolver = new IcsEventSpanResolver(new CalendarEntryTimeRules());
+        $this->reader = new IcsOccurrenceReader();
         $this->berlin = new \DateTimeZone('Europe/Berlin');
     }
 
@@ -180,9 +183,59 @@ final class IcsEventSpanResolverTest extends TestCase
     }
 
     /** @param array<string, string> $event */
+    /**
+     * Wraps the properties into a one-event feed and takes it through the real
+     * reader, so these cases cover both halves of the import: reading a
+     * property into an instant, and turning that into the days it covers.
+     *
+     * @param array<string, string> $event
+     */
     private function resolve(array $event): ?\App\Dto\Ics\IcsEventSpan
     {
-        return $this->resolver->resolve($event, $this->berlin);
+        $occurrence = $this->read($event);
+
+        return null === $occurrence ? null : $this->resolver->resolve($occurrence);
+    }
+
+    /**
+     * @param array<string, string> $event
+     */
+    private function read(array $event): ?IcsOccurrence
+    {
+        $properties = '';
+        foreach (['DTSTART', 'DTEND'] as $name) {
+            if (!isset($event[$name])) {
+                continue;
+            }
+
+            $value = $event[$name];
+            $params = $event[$name.';PARAMS'] ?? null;
+            // A bare eight-digit value is a date without a time, which RFC 5545
+            // only treats as such when VALUE=DATE says so.
+            if (null === $params && 8 === \strlen($value) && ctype_digit($value)) {
+                $params = 'VALUE=DATE';
+            }
+
+            $properties .= $name.(null !== $params ? ';'.$params : '').':'.$value."\r\n";
+        }
+
+        $ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//test//test//EN\r\n"
+            ."BEGIN:VEVENT\r\nUID:test\r\nSUMMARY:Test\r\n".$properties."END:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        // Deliberately wide, so a case is never discarded for sitting outside
+        // the window when what it means to check is the span arithmetic.
+        try {
+            $result = $this->reader->read(
+                $ics,
+                $this->berlin,
+                new \DateTimeImmutable('2000-01-01', $this->berlin),
+                new \DateTimeImmutable('2100-01-01', $this->berlin),
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $result->occurrences[0] ?? null;
     }
 
     /**

--- a/translations/Calendar/messages.de.yaml
+++ b/translations/Calendar/messages.de.yaml
@@ -37,7 +37,6 @@ calendar:
     synced: "Kalender wurde synchronisiert: %new% neu, %updated% aktualisiert, %unchanged% unverändert."
     synced_empty: "Sync durchgeführt, aber keine Einträge in der Quelle gefunden – bisherige Einträge bleiben unverändert aktiv."
     sync_failed: "Kalender konnte nicht synchronisiert werden: %message%"
-    synced_recurring_skipped: "%count% wiederkehrende Termine wurden übersprungen – Serientermine (z.B. jährliche Geburtstage) werden nicht aufgelöst. Solche Termine bitte manuell anlegen oder eine Quelle verwenden, die jeden Termin einzeln exportiert."
     synced_invalid_skipped: "%count% Termine wurden übersprungen, weil ihr Zeitraum nicht lesbar war – z.B. ein Ende vor oder gleich dem Beginn. Solche Termine werden verworfen statt auf einen geratenen Tag gelegt."
   cleanup:
     title: "Vergangene Termine aufräumen"

--- a/translations/Calendar/messages.en.yaml
+++ b/translations/Calendar/messages.en.yaml
@@ -37,7 +37,6 @@ calendar:
     synced: "Calendar synced: %new% new, %updated% updated, %unchanged% unchanged."
     synced_empty: "Sync ran, but the source had no entries - existing entries remain unchanged."
     sync_failed: "Calendar could not be synced: %message%"
-    synced_recurring_skipped: "%count% recurring entries were skipped - repeating events (e.g. yearly birthdays) are not expanded. Add such entries manually, or use a source that exports every occurrence separately."
     synced_invalid_skipped: "%count% entries were skipped because their period could not be read - for example an end before or equal to the start. Such events are discarded rather than filed under a guessed day."
   cleanup:
     title: "Clean up past entries"

--- a/translations/validators.de.xlf
+++ b/translations/validators.de.xlf
@@ -62,6 +62,10 @@
                 <source>invoice_number_pattern.empty</source>
                 <target>Bitte ein Muster angeben.</target>
             </trans-unit>
+            <trans-unit id="calendar.form.ics_file_invalid">
+                <source>calendar.form.ics_file_invalid</source>
+                <target>Bitte eine gültige ICS-Datei (.ics) hochladen.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/validators.en.yaml
+++ b/translations/validators.en.yaml
@@ -1,3 +1,6 @@
+calendar:
+  form:
+    ics_file_invalid: Please upload a valid ICS (.ics) file.
 form:
   email:
     notblank: Please enter your e-mail address.


### PR DESCRIPTION
https://github.com/developeregrem/fewohbee/pull/263#issuecomment-5331504291

A calendar feed that states its dates through an `RRULE` imported nothing at
all: the events were skipped and counted. They are now expanded into one entry
per occurrence, read through sabre/vobject's `EventIterator`.

## Expansion

The iterator rather than `VCalendar::expand()`: `expand()` rewrites every
instant into the zone handed to it and refuses the whole calendar when a single
event carries an unusable recurrence. The iterator works per event, so one
broken `VEVENT` is counted while the rest of the feed still imports — which is
what `skippedInvalid` has always been for.

A rule without `UNTIL` or `COUNT` never ends, so the import runs against a
window: two years ahead, moving with every sync, starting at today. Reading from
today files nothing behind it, because `fastForward()` goes by an occurrence's
end — a multi-day event still running keeps the days it has left.

One event contributes at most `MAX_OCCURRENCES_PER_EVENT` instances. Beyond
that it is discarded whole rather than cut off partway: handing over the first
thousand of a runaway rule would fill the calendar with rows nobody can tell
from real ones.

## Entries that have aged into the past

Rows that were filed when they were still ahead are now left alone: not
matched, not reused for another date, not removed. Clearing them out is the
user's decision through `deleteUnconfirmedPast()` — previously the next hourly
run resurrected whatever that button had just deleted, because the creation
path checked no date at all.

## Exceptions inside a series

A series and its `RECURRENCE-ID` overrides are separate `VEVENT`s sharing one
UID, and each may state its own `SUMMARY` — the bin collection that moves
because of a public holiday says so in its title. Titles are therefore
collected per date, the way times and end times already were, instead of one
per UID where whichever `VEVENT` came last named the whole series.

`EXDATE`, the other way a feed states an exception, needed no change; both
directions are pinned by tests now — a date excluded from the start is never
filed, and one excluded later takes its entry with it on the next import.

## Also here

`calendar.form.ics_file_invalid` was defined in the `Calendar` domain while
Symfony looks validation messages up in `validators`, so picking the wrong file
showed the raw key. Added there in both languages.

`skippedRecurring` and its flash message are gone — nothing is skipped for
being recurring any more. `IcsEventParser` keeps only what the channel-manager
reservation sync still calls; it goes away entirely once that path follows.

## Tests

`bin/run-tests.sh tests/Functional/CalendarEntrySyncServiceTest.php` — 42 tests
covering expansion, the moving window, multi-day events that are already
running, the two exception mechanisms, and the caps. `IcsEventSpanResolver`'s
unit tests now run through the real reader and pin "today" through the clock
service, so they no longer expire once real time passes their fixture dates.
