### PR TITLE
Offer a payment QR code to invoice templates

### DIFF
--- a/assets/controllers/template_editor_controller.js
+++ b/assets/controllers/template_editor_controller.js
@@ -67,6 +67,39 @@ const TemplateTableHeader = extendWithTemplateAttrs(TableHeader, repeatAndCondit
 const TemplateTableCell = extendWithTemplateAttrs(TableCell, repeatAndConditionAttributes(), styleAndClassAttributes());
 
 /**
+ * An <img> whose src is a template expression cannot be fetched by the browser, so the
+ * visual editor would show a broken-image icon exactly where a picture appears at render
+ * time. These helpers put a neutral placeholder in its place, labelled with the
+ * expression, while the node attribute keeps the expression untouched for saving.
+ */
+const TEMPLATE_EXPRESSION = /\[\[|\[%|\{\{|\{%/;
+
+const isTemplateExpression = (src) => TEMPLATE_EXPRESSION.test(src || '');
+
+const templateImagePlaceholder = (src) => {
+    const label = String(src || '').replace(/[\[\]{}%]/g, '').trim().slice(0, 30);
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
+        <rect x="2" y="2" width="156" height="156" rx="6" fill="#f3f4f6" stroke="#9ca3af"
+              stroke-width="2" stroke-dasharray="6 4"/>
+        <g fill="#9ca3af">
+            <rect x="34" y="34" width="30" height="30" rx="3"/>
+            <rect x="96" y="34" width="30" height="30" rx="3"/>
+            <rect x="34" y="96" width="30" height="30" rx="3"/>
+            <rect x="80" y="80" width="12" height="12"/>
+            <rect x="104" y="104" width="12" height="12"/>
+            <rect x="80" y="128" width="12" height="12"/>
+        </g>
+        <text x="80" y="152" font-family="sans-serif" font-size="9" fill="#6b7280"
+              text-anchor="middle">${label}</text>
+    </svg>`;
+
+    return 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg);
+};
+
+/** What the browser should actually load for a given node src. */
+const displayImageSrc = (src) => (isTemplateExpression(src) ? templateImagePlaceholder(src) : (src || ''));
+
+/**
  * Resizable image extension with drag handles and alignment support.
  * Stores width as an HTML attribute so it survives code ↔ visual round-trips.
  */
@@ -98,9 +131,10 @@ const ResizableImage = Image.extend({
             wrapper.contentEditable = 'false';
 
             const img = document.createElement('img');
-            img.src = node.attrs.src || '';
+            img.src = displayImageSrc(node.attrs.src);
             if (node.attrs.alt) img.alt = node.attrs.alt;
             if (node.attrs.title) img.title = node.attrs.title;
+            else if (isTemplateExpression(node.attrs.src)) img.title = node.attrs.src;
             if (node.attrs.width) img.style.width = node.attrs.width;
 
             // Alignment toolbar — sets text-align on the parent <p> so mPDF can use it
@@ -174,7 +208,8 @@ const ResizableImage = Image.extend({
                 dom: wrapper,
                 update: (updatedNode) => {
                     if (updatedNode.type.name !== 'image') return false;
-                    img.src = updatedNode.attrs.src || '';
+                    img.src = displayImageSrc(updatedNode.attrs.src);
+                    if (isTemplateExpression(updatedNode.attrs.src)) img.title = updatedNode.attrs.src;
                     if (updatedNode.attrs.alt) img.alt = updatedNode.attrs.alt;
                     img.style.width = updatedNode.attrs.width || '';
                     return true;

--- a/assets/controllers/template_editor_controller.js
+++ b/assets/controllers/template_editor_controller.js
@@ -96,6 +96,18 @@ const templateImagePlaceholder = (src) => {
     return 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg);
 };
 
+/**
+ * Replaces the width inside an inline style, leaving a style that states none alone.
+ * An image can carry its width twice — as the attribute and in the style — and mPDF
+ * follows the style, so a resize that only updated the attribute would show up in the
+ * editor and nowhere else.
+ */
+const withWidthInStyle = (style, width) => (
+    style && /(^|;)\s*width\s*:/i.test(style)
+        ? style.replace(/(^|;)(\s*)width\s*:[^;]*/gi, `$1$2width: ${width}`)
+        : style
+);
+
 /** What the browser should actually load for a given node src. */
 const displayImageSrc = (src) => (isTemplateExpression(src) ? templateImagePlaceholder(src) : (src || ''));
 
@@ -173,10 +185,21 @@ const ResizableImage = Image.extend({
                 if (typeof getPos !== 'function') return;
                 const pos = getPos();
                 if (pos == null) return;
-                const newWidth = Math.max(30, startWidth + (e.clientX - startX));
-                editor.chain().focus()
-                    .updateAttributes('image', { width: newWidth + 'px' })
-                    .run();
+                const newWidth = Math.max(30, startWidth + (e.clientX - startX)) + 'px';
+
+                // Addressed by position instead of through updateAttributes(), which acts
+                // on the current selection. Clicking the image first does select the node,
+                // so the drag sticks — but grabbing the handle straight from a text
+                // selection leaves nothing for that command to act on, and the new width
+                // is dropped without a trace. The position does not depend on either.
+                const { state, dispatch } = editor.view;
+                const target = state.doc.nodeAt(pos);
+                if (!target) return;
+                dispatch(state.tr.setNodeMarkup(pos, undefined, {
+                    ...target.attrs,
+                    width: newWidth,
+                    style: withWidthInStyle(target.attrs.style, newWidth),
+                }));
             };
 
             handle.addEventListener('mousedown', (e) => {

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "doctrine/doctrine-fixtures-bundle": "^4.0",
         "doctrine/doctrine-migrations-bundle": "^4.0",
         "doctrine/orm": "^3.6",
+        "endroid/qr-code": "^6.1",
         "horstoeko/zugferd": "^1.0",
         "league/flysystem-aws-s3-v3": "^3",
         "mpdf/mpdf": "^8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c283de58ad4dbe259c1b18090d17aac1",
+    "content-hash": "dc0f00b2fac4b0d0feb7ac9c96cc98c6",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -231,6 +231,61 @@
             "time": "2026-03-30T13:35:38+00:00"
         },
         {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "spatie/pixelmatch-php": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
+            },
+            "time": "2026-04-05T21:06:35+00:00"
+        },
+        {
             "name": "brick/math",
             "version": "0.18.0",
             "source": {
@@ -365,6 +420,56 @@
                 }
             ],
             "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
+            },
+            "time": "2025-09-16T12:23:56+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -1721,6 +1826,78 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "endroid/qr-code",
+            "version": "6.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/endroid/qr-code.git",
+                "reference": "5fa534856ed95649d67c0eab0cabc03ab1d8e0e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/5fa534856ed95649d67c0eab0cabc03ab1d8e0e2",
+                "reference": "5fa534856ed95649d67c0eab0cabc03ab1d8e0e2",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^3.0",
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "endroid/quality": "dev-main",
+                "ext-gd": "*",
+                "khanamiryan/qrcode-detector-decoder": "^2.0.3",
+                "setasign/fpdf": "^1.8.2"
+            },
+            "suggest": {
+                "ext-gd": "Enables you to write PNG images",
+                "khanamiryan/qrcode-detector-decoder": "Enables you to use the image validator",
+                "roave/security-advisories": "Makes sure package versions with known security issues are not installed",
+                "setasign/fpdf": "Enables you to use the PDF writer"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Endroid\\QrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeroen van den Enden",
+                    "email": "info@endroid.nl"
+                }
+            ],
+            "description": "Endroid QR Code",
+            "homepage": "https://github.com/endroid/qr-code",
+            "keywords": [
+                "code",
+                "endroid",
+                "php",
+                "qr",
+                "qrcode"
+            ],
+            "support": {
+                "issues": "https://github.com/endroid/qr-code/issues",
+                "source": "https://github.com/endroid/qr-code/tree/6.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/endroid",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-05T07:01:58+00:00"
         },
         {
             "name": "goetas-webservices/xsd2php-runtime",

--- a/src/Service/PaymentQrCodeService.php
+++ b/src/Service/PaymentQrCodeService.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the guesthouse administration package.
+ *
+ * (c) Alexander Elchlepp <info@fewohbee.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service;
+
+use App\Entity\Invoice;
+use App\Entity\InvoiceSettingsData;
+use App\Service\EInvoice\EInvoiceReadinessService;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\ErrorCorrectionLevel;
+use Endroid\QrCode\Writer\PngWriter;
+
+/**
+ * Builds an EPC069-12 payment QR code ("GiroCode") for an invoice.
+ *
+ * Scanning the code fills a SEPA credit transfer in the payer's banking app, so
+ * nobody has to retype IBAN, amount and invoice number. The payload is the plain
+ * text defined by EPC069-12: twelve newline separated lines, at most 331 bytes.
+ *
+ * The code is offered to templates as a `data:` URI placeholder. Whether it ends
+ * up on the invoice — and whether that makes sense for the payment method at hand —
+ * is left to the template, which can check `invoice.paymentMeans` and `invoice.status`.
+ */
+final class PaymentQrCodeService
+{
+    private const SERVICE_TAG = 'BCD';
+    /** Version 002 makes the BIC optional, which SEPA no longer requires. */
+    private const VERSION = '002';
+    /** Character set 1 = UTF-8. */
+    private const CHARACTER_SET = '1';
+    private const IDENTIFICATION = 'SCT';
+
+    /** EPC069-12 is a euro-only scheme; there is no way to express another currency. */
+    private const CURRENCY = 'EUR';
+    private const MAX_NAME_LENGTH = 70;
+    private const MAX_REMITTANCE_LENGTH = 140;
+    private const MIN_AMOUNT = 0.01;
+    private const MAX_AMOUNT = 999999999.99;
+    /** The scheme caps the whole payload, not just the individual lines. */
+    private const MAX_PAYLOAD_BYTES = 331;
+
+    /**
+     * Rendered codes per invoice and pixel size, for the lifetime of the request:
+     * a template that guards with an if and then prints the code asks twice.
+     *
+     * @var array<string, string|null>
+     */
+    private array $rendered = [];
+
+    public function __construct(
+        private readonly EInvoiceReadinessService $readinessService,
+        private readonly AppSettingsService $appSettingsService,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * Returns the QR code as a base64 encoded PNG `data:` URI, or null when the
+     * invoice cannot be paid by credit transfer as it stands — missing bank
+     * details, a non-euro installation, or an amount outside the range
+     * EPC069-12 allows.
+     */
+    public function buildDataUri(Invoice $invoice, float $amount, int $size = 300): ?string
+    {
+        $cacheKey = ((string) $invoice->getId()).'|'.$size.'|'.$amount;
+        if (\array_key_exists($cacheKey, $this->rendered)) {
+            return $this->rendered[$cacheKey];
+        }
+
+        $payload = $this->buildPayload($invoice, $amount);
+        if (null === $payload) {
+            return $this->rendered[$cacheKey] = null;
+        }
+
+        return $this->rendered[$cacheKey] = (new Builder(
+            writer: new PngWriter(),
+            data: $payload,
+            // Medium leaves the code readable on a printed invoice that got folded.
+            errorCorrectionLevel: ErrorCorrectionLevel::Medium,
+            size: $size,
+            margin: 0,
+        ))->build()->getDataUri();
+    }
+
+    /**
+     * Assembles the twelve EPC069-12 lines. Returns null when a required field is
+     * missing, so callers can leave the code off instead of printing a broken one.
+     */
+    public function buildPayload(Invoice $invoice, float $amount): ?string
+    {
+        // The scheme only carries euro amounts, so a shop running another currency
+        // would get a code demanding the wrong money.
+        if (self::CURRENCY !== strtoupper($this->appSettingsService->getSettings()->getCurrency())) {
+            return null;
+        }
+
+        // Issuer data follows the invoice's branch, so a two-company setup puts the
+        // right account on each code instead of whichever row is globally active.
+        $settings = $this->readinessService->resolveSettingsFor($invoice);
+        if (!$settings instanceof InvoiceSettingsData) {
+            return null;
+        }
+
+        $iban = $this->compact((string) $settings->getAccountIBAN());
+        $name = trim((string) ($settings->getAccountName() ?: $settings->getCompanyName()));
+
+        if ('' === $iban || '' === $name) {
+            return null;
+        }
+
+        if ($amount < self::MIN_AMOUNT || $amount > self::MAX_AMOUNT) {
+            return null;
+        }
+
+        $lines = [
+            self::SERVICE_TAG,
+            self::VERSION,
+            self::CHARACTER_SET,
+            self::IDENTIFICATION,
+            $this->compact((string) $settings->getAccountBIC()),
+            $this->cut($name, self::MAX_NAME_LENGTH),
+            $iban,
+            self::CURRENCY.number_format($amount, 2, '.', ''),
+            '',  // purpose code
+            '',  // structured creditor reference, mutually exclusive with the line below
+            $this->cut($this->buildRemittanceInfo($invoice), self::MAX_REMITTANCE_LENGTH),
+            '',  // beneficiary to originator information
+        ];
+
+        $payload = implode("\n", $lines);
+
+        // Truncating the individual lines is not enough: those caps count characters
+        // while the scheme counts bytes, so an umlaut holder name can weigh twice its
+        // length. Banking apps reject an oversized code outright rather than showing a
+        // partial transfer.
+        return \strlen($payload) > self::MAX_PAYLOAD_BYTES ? null : $payload;
+    }
+
+    /**
+     * The remittance text shows up in the payer's banking app, so it is translated
+     * rather than hardcoded German.
+     */
+    private function buildRemittanceInfo(Invoice $invoice): string
+    {
+        $number = trim((string) $invoice->getNumber());
+        if ('' === $number) {
+            return '';
+        }
+
+        return $this->translator->trans('invoice.payment_qr.remittance', ['%number%' => $number]);
+    }
+
+    /**
+     * IBAN and BIC are stored the way they were typed; the payload wants them
+     * without spaces and in upper case.
+     */
+    private function compact(string $value): string
+    {
+        return strtoupper(preg_replace('/\s+/', '', $value) ?? '');
+    }
+
+    private function cut(string $value, int $max): string
+    {
+        return mb_substr($value, 0, $max);
+    }
+}

--- a/src/Service/PaymentQrCodeService.php
+++ b/src/Service/PaymentQrCodeService.php
@@ -51,6 +51,20 @@ final class PaymentQrCodeService
     private const MAX_PAYLOAD_BYTES = 331;
 
     /**
+     * Bounds for the requested edge length, because the size comes from a template
+     * and templates are written by hand.
+     *
+     * Below the lower bound the encoder refuses a full-length payload outright
+     * ("Too much data"), which would surface as an exception in the middle of an
+     * invoice. Above the upper bound nothing is gained and a lot is paid: memory and
+     * time grow with the square of the edge, and an 8000 px code costs half a
+     * gigabyte and five seconds — enough to take the worker down with it. 1000 px is
+     * around 85 mm at 300 dpi, past anything a printed invoice asks for.
+     */
+    private const MIN_SIZE = 100;
+    private const MAX_SIZE = 1000;
+
+    /**
      * Rendered codes per invoice and pixel size, for the lifetime of the request:
      * a template that guards with an if and then prints the code asks twice.
      *
@@ -70,9 +84,17 @@ final class PaymentQrCodeService
      * invoice cannot be paid by credit transfer as it stands — missing bank
      * details, a non-euro installation, or an amount outside the range
      * EPC069-12 allows.
+     *
+     * @param int $size edge length of the generated image in pixels, clamped to
+     *                  MIN_SIZE..MAX_SIZE; how large the code appears on the page is
+     *                  a matter for the template, not for this number
      */
     public function buildDataUri(Invoice $invoice, float $amount, int $size = 300): ?string
     {
+        // Clamped before the cache key so two requests that end up at the same edge
+        // length share the one rendered code.
+        $size = max(self::MIN_SIZE, min(self::MAX_SIZE, $size));
+
         $cacheKey = ((string) $invoice->getId()).'|'.$size.'|'.$amount;
         if (\array_key_exists($cacheKey, $this->rendered)) {
             return $this->rendered[$cacheKey];

--- a/src/Service/TemplatePreview/InvoiceTemplatePreviewProvider.php
+++ b/src/Service/TemplatePreview/InvoiceTemplatePreviewProvider.php
@@ -246,6 +246,13 @@ class InvoiceTemplatePreviewProvider implements ITemplatePreviewProvider
                 'content' => "<table style=\"width: 100%;\" data-if=\"invoice.positions|filter(p => p.positionGroup == 'tourist_tax')|length > 0\">\n  <tbody>\n    <tr>\n      <th>{{ 'invoice.tourist_tax.heading'|trans }}</th>\n      <th>{{ 'invoice.position.amount'|trans }}</th>\n      <th>{{ 'invoice.price.single'|trans }}</th>\n      <th>{{ 'invoice.vat'|trans }}</th>\n      <th style=\"text-align: right;\">{{ 'invoice.price.total'|trans }}</th>\n    </tr>\n    <tr data-repeat=\"invoice.positions|filter(p => p.positionGroup == 'tourist_tax')\" data-repeat-as=\"position\">\n      <td>[[ position.description ]]</td>\n      <td>[[ position.amount ]]</td>\n      <td>[[ position.priceFormated ]] €</td>\n      <td>[[ position.vat ]]</td>\n      <td style=\"text-align: right;\">[[ position.totalPrice ]] €</td>\n    </tr>\n  </tbody>\n</table>",
             ],
             [
+                'id' => 'invoice.payment_qr',
+                'label' => 'templates.editor.payment_qr',
+                'group' => 'Invoice',
+                'complexity' => 'easy',
+                'content' => "<div data-if=\"payment_qr(invoice)\"><img src=\"[[ payment_qr(invoice, 300) ]]\" alt=\"\" style=\"width: 30mm;\"></div>",
+            ],
+            [
                 'id' => 'pdf.header',
                 'label' => 'templates.preview.snippet.pdf_header',
                 'group' => 'PDF',

--- a/src/Service/TemplatePreview/InvoiceTemplatePreviewProvider.php
+++ b/src/Service/TemplatePreview/InvoiceTemplatePreviewProvider.php
@@ -250,7 +250,7 @@ class InvoiceTemplatePreviewProvider implements ITemplatePreviewProvider
                 'label' => 'templates.editor.payment_qr',
                 'group' => 'Invoice',
                 'complexity' => 'easy',
-                'content' => "<div data-if=\"payment_qr(invoice)\"><img src=\"[[ payment_qr(invoice, 300) ]]\" alt=\"\" style=\"width: 30mm;\"></div>",
+                'content' => "<div data-if=\"payment_qr(invoice)\"><img src=\"[[ payment_qr(invoice, 300) ]]\" alt=\"\" width=\"30mm\"></div>",
             ],
             [
                 'id' => 'pdf.header',

--- a/src/Twig/PaymentQrExtension.php
+++ b/src/Twig/PaymentQrExtension.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the guesthouse administration package.
+ *
+ * (c) Alexander Elchlepp <info@fewohbee.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig;
+
+use App\Entity\Invoice;
+use App\Service\InvoiceService;
+use App\Service\PaymentQrCodeService;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Makes the EPC069-12 payment QR code available to invoice templates.
+ *
+ * Offered as a function rather than a render parameter for two reasons: the pixel
+ * size belongs in the hands of whoever lays out the template, and a function is only
+ * evaluated where it is used — building a code costs about 20 ms, which no template
+ * should pay for a placeholder it never prints.
+ */
+final class PaymentQrExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly PaymentQrCodeService $paymentQrCodeService,
+        private readonly InvoiceService $invoiceService,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('payment_qr', $this->paymentQr(...)),
+        ];
+    }
+
+    /**
+     * Returns the QR code as a `data:` URI ready for an `<img src>`, or an empty
+     * string when the invoice cannot be paid by credit transfer as it stands —
+     * no bank details, a non-euro installation, an amount the scheme cannot carry.
+     * The empty string keeps `data-if="payment_qr(invoice)"` working as a guard.
+     *
+     * @param int $size edge length of the generated image in pixels; the size on
+     *                  the page is a matter for the template's own CSS
+     */
+    public function paymentQr(Invoice $invoice, int $size = 300): string
+    {
+        return $this->paymentQrCodeService->buildDataUri($invoice, $this->grossTotal($invoice), $size) ?? '';
+    }
+
+    /**
+     * The amount the guest is asked to transfer: the invoice total including VAT,
+     * rounded per VAT rate the same way the printed total is.
+     */
+    private function grossTotal(Invoice $invoice): float
+    {
+        $vatSums = [];
+        $brutto = 0;
+        $netto = 0;
+        $appartmentTotal = 0;
+        $miscTotal = 0;
+
+        $this->invoiceService->calculateSums(
+            $invoice->getAppartments(),
+            $invoice->getPositions(),
+            $vatSums,
+            $brutto,
+            $netto,
+            $appartmentTotal,
+            $miscTotal
+        );
+
+        return (float) $brutto;
+    }
+}

--- a/tests/Unit/PaymentQrCodeServiceTest.php
+++ b/tests/Unit/PaymentQrCodeServiceTest.php
@@ -142,6 +142,59 @@ final class PaymentQrCodeServiceTest extends TestCase
         $this->assertNotNull($this->createService($settings)->buildPayload($this->createInvoice(), 10.0));
     }
 
+    public function testDataUriIsAPngOfTheRequestedSize(): void
+    {
+        $uri = $this->createService($this->createSettings())->buildDataUri($this->createInvoice(), 10.0, 300);
+
+        self::assertIsString($uri);
+        self::assertStringStartsWith('data:image/png;base64,', $uri);
+        self::assertSame([300, 300], $this->pixelSize($uri));
+    }
+
+    /**
+     * The size comes from a template, so it has to survive a typo. Memory and time
+     * grow with the square of the edge; an unbounded value takes the worker down.
+     */
+    public function testAnOversizedRequestIsCapped(): void
+    {
+        $uri = $this->createService($this->createSettings())->buildDataUri($this->createInvoice(), 10.0, 8000);
+
+        self::assertSame([1000, 1000], $this->pixelSize((string) $uri));
+    }
+
+    /** Below the floor the encoder refuses a full-length payload outright. */
+    public function testAnUndersizedRequestIsRaisedToTheFloor(): void
+    {
+        $uri = $this->createService($this->createSettings())->buildDataUri($this->createInvoice(), 10.0, 10);
+
+        self::assertSame([100, 100], $this->pixelSize((string) $uri));
+    }
+
+    /** Even at the floor, the longest payload the scheme carries still encodes. */
+    public function testTheFloorStillEncodesAMaximalPayload(): void
+    {
+        $settings = $this->createSettings();
+        $settings->setAccountName(str_repeat('a', 70));
+
+        $uri = $this->createService($settings)->buildDataUri($this->createInvoice(str_repeat('9', 60)), 999999999.99, 1);
+
+        self::assertSame([100, 100], $this->pixelSize((string) $uri));
+    }
+
+    public function testNoDataUriWhenNoPayloadIsPossible(): void
+    {
+        self::assertNull($this->createService(null)->buildDataUri($this->createInvoice(), 10.0));
+    }
+
+    /** @return array{int, int} */
+    private function pixelSize(string $dataUri): array
+    {
+        $png = base64_decode(substr($dataUri, \strlen('data:image/png;base64,')), true);
+        $info = getimagesizefromstring((string) $png);
+
+        return [$info[0] ?? 0, $info[1] ?? 0];
+    }
+
     private function createService(?InvoiceSettingsData $settings, string $currency = 'EUR'): PaymentQrCodeService
     {
         $readiness = $this->createStub(EInvoiceReadinessService::class);

--- a/tests/Unit/PaymentQrCodeServiceTest.php
+++ b/tests/Unit/PaymentQrCodeServiceTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\Entity\AppSettings;
+use App\Entity\Invoice;
+use App\Entity\InvoiceSettingsData;
+use App\Service\AppSettingsService;
+use App\Service\EInvoice\EInvoiceReadinessService;
+use App\Service\PaymentQrCodeService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class PaymentQrCodeServiceTest extends TestCase
+{
+    public function testPayloadFollowsTheEpcLineOrder(): void
+    {
+        $service = $this->createService($this->createSettings());
+
+        $payload = $service->buildPayload($this->createInvoice('2026-0007'), 1342.5);
+
+        $this->assertSame([
+            'BCD',
+            '002',
+            '1',
+            'SCT',
+            'LUHSDE6AXXX',
+            'Thomas Lisowski',
+            'DE64545500100240006924',
+            'EUR1342.50',
+            '',
+            '',
+            'Rechnung 2026-0007',
+            '',
+        ], explode("\n", (string) $payload));
+    }
+
+    /** The IBAN is stored the way it was typed, the payload wants it without spaces. */
+    public function testIbanAndBicAreCompacted(): void
+    {
+        $settings = $this->createSettings();
+        $settings->setAccountIBAN('DE64 5455 0010 0240 0069 24');
+        $settings->setAccountBIC('luhsde6axxx');
+
+        $payload = (string) $this->createService($settings)->buildPayload($this->createInvoice(), 10.0);
+        $lines = explode("\n", $payload);
+
+        $this->assertSame('LUHSDE6AXXX', $lines[4]);
+        $this->assertSame('DE64545500100240006924', $lines[6]);
+    }
+
+    public function testAmountIsFormattedWithADecimalPoint(): void
+    {
+        $payload = (string) $this->createService($this->createSettings())->buildPayload($this->createInvoice(), 89.5);
+
+        $this->assertSame('EUR89.50', explode("\n", $payload)[7]);
+    }
+
+    public function testNoPayloadWithoutBankDetails(): void
+    {
+        $settings = $this->createSettings();
+        $settings->setAccountIBAN('');
+
+        $this->assertNull($this->createService($settings)->buildPayload($this->createInvoice(), 10.0));
+    }
+
+    public function testNoPayloadWithoutConfiguredInvoiceSettings(): void
+    {
+        $this->assertNull($this->createService(null)->buildPayload($this->createInvoice(), 10.0));
+    }
+
+    /** EPC069-12 carries euro amounts only, so another currency must not produce a code. */
+    public function testNoPayloadOutsideTheEuroZone(): void
+    {
+        $service = $this->createService($this->createSettings(), 'CHF');
+
+        $this->assertNull($service->buildPayload($this->createInvoice(), 10.0));
+    }
+
+    public function testNoPayloadForAnAmountOutsideTheAllowedRange(): void
+    {
+        $service = $this->createService($this->createSettings());
+
+        $this->assertNull($service->buildPayload($this->createInvoice(), 0.0));
+        $this->assertNull($service->buildPayload($this->createInvoice(), 1_000_000_000.0));
+    }
+
+    /** A beneficiary name longer than the 70 characters EPC069-12 allows is cut, not rejected. */
+    public function testLongBeneficiaryNameIsTruncated(): void
+    {
+        $settings = $this->createSettings();
+        $settings->setAccountName(str_repeat('a', 90));
+
+        $payload = (string) $this->createService($settings)->buildPayload($this->createInvoice(), 10.0);
+
+        $this->assertSame(70, mb_strlen(explode("\n", $payload)[5]));
+    }
+
+    public function testRemittanceStaysEmptyWithoutAnInvoiceNumber(): void
+    {
+        $payload = (string) $this->createService($this->createSettings())->buildPayload(new Invoice(), 10.0);
+
+        $this->assertSame('', explode("\n", $payload)[10]);
+    }
+
+    /** The issuer follows the invoice's branch, so each company's own account is used. */
+    public function testSettingsAreResolvedForTheInvoicesSubsidiary(): void
+    {
+        $branchSettings = $this->createSettings();
+        $branchSettings->setAccountIBAN('DE02120300000000202051');
+        $branchSettings->setAccountName('Zweites Haus');
+
+        $payload = (string) $this->createService($branchSettings)->buildPayload($this->createInvoice(), 10.0);
+        $lines = explode("\n", $payload);
+
+        $this->assertSame('Zweites Haus', $lines[5]);
+        $this->assertSame('DE02120300000000202051', $lines[6]);
+    }
+
+    /**
+     * The per-line caps count characters while the scheme counts bytes, so an umlaut
+     * holder name plus a long remittance can still overrun it. Banking apps reject an
+     * oversized code, and no code is better than a broken one.
+     */
+    public function testNoPayloadWhenTheLinesTogetherExceedTheSchemeLimit(): void
+    {
+        $settings = $this->createSettings();
+        $settings->setAccountName(str_repeat('ä', 70));
+
+        $service = $this->createService($settings);
+        $this->assertNull($service->buildPayload($this->createInvoice(str_repeat('9', 140)), 10.0));
+    }
+
+    /** The same long name stays fine as long as it is plain ASCII. */
+    public function testAsciiNameOfTheSameLengthStillFits(): void
+    {
+        $settings = $this->createSettings();
+        $settings->setAccountName(str_repeat('a', 70));
+
+        $this->assertNotNull($this->createService($settings)->buildPayload($this->createInvoice(), 10.0));
+    }
+
+    private function createService(?InvoiceSettingsData $settings, string $currency = 'EUR'): PaymentQrCodeService
+    {
+        $readiness = $this->createStub(EInvoiceReadinessService::class);
+        $readiness->method('resolveSettingsFor')->willReturn($settings);
+
+        $appSettings = new AppSettings();
+        $appSettings->setCurrency($currency);
+
+        $appSettingsService = $this->createStub(AppSettingsService::class);
+        $appSettingsService->method('getSettings')->willReturn($appSettings);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params = []) => 'Rechnung '.($params['%number%'] ?? '')
+        );
+
+        return new PaymentQrCodeService($readiness, $appSettingsService, $translator);
+    }
+
+    private function createSettings(): InvoiceSettingsData
+    {
+        $settings = new InvoiceSettingsData();
+        $settings->setAccountName('Thomas Lisowski');
+        $settings->setAccountIBAN('DE64545500100240006924');
+        $settings->setAccountBIC('LUHSDE6AXXX');
+
+        return $settings;
+    }
+
+    private function createInvoice(string $number = '2026-0001'): Invoice
+    {
+        $invoice = new Invoice();
+        $invoice->setNumber($number);
+
+        return $invoice;
+    }
+}

--- a/translations/Invoices/messages.de.xlf
+++ b/translations/Invoices/messages.de.xlf
@@ -738,6 +738,10 @@
                 <source>invoice.tourist_tax.no_positions</source>
                 <target>Für diese Buchung wurden keine Beherbergungsabgaben berechnet.</target>
             </trans-unit>
+            <trans-unit id="invoice.payment_qr.remittance">
+                <source>invoice.payment_qr.remittance</source>
+                <target>Rechnung %number%</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/Invoices/messages.en.yaml
+++ b/translations/Invoices/messages.en.yaml
@@ -185,3 +185,4 @@ invoice.tourist_tax.position.percent_per_room: '%tax% (%percent% %% of overnight
 invoice.tourist_tax.position.nights: '{0} %count% nights|{1} %count% night|]1,Inf] %count% nights'
 invoice.tourist_tax.position.persons: '{0} %count% people|{1} %count% person|]1,Inf] %count% people'
 invoice.tourist_tax.no_positions: No tourist tax lines were calculated for this booking.
+invoice.payment_qr.remittance: Invoice %number%

--- a/translations/Templates/messages.de.xlf
+++ b/translations/Templates/messages.de.xlf
@@ -836,7 +836,7 @@
             </trans-unit>
             <trans-unit id="templates.editor.payment_qr.desc">
                 <source>templates.editor.payment_qr.desc</source>
-                <target>Fügt einen QR-Code ein, der in der Banking-App des Zahlenden eine SEPA-Überweisung vorausfüllt. Die Zahl ist die Auflösung des Bildes in Pixeln; wie groß es auf der Seite erscheint, bestimmt das CSS. Der Code erscheint nur, wenn in den Rechnungseinstellungen eine Bankverbindung hinterlegt ist und die Installation in Euro rechnet.</target>
+                <target>Fügt einen QR-Code ein, der in der Banking-App des Zahlenden eine SEPA-Überweisung vorausfüllt. Die Zahl ist die Auflösung des Bildes in Pixeln; wie groß es auf der Seite erscheint, bestimmt die Breite des Bildes, die du am Ziehpunkt einstellst. Der Code erscheint nur, wenn in den Rechnungseinstellungen eine Bankverbindung hinterlegt ist und die Installation in Euro rechnet.</target>
             </trans-unit>
             <trans-unit id="templates.notfound">
                 <source>templates.notfound</source>

--- a/translations/Templates/messages.de.xlf
+++ b/translations/Templates/messages.de.xlf
@@ -830,6 +830,14 @@
                 <source>templates.editor.tourist_tax.positions.desc</source>
                 <target>Fügt eine Tabelle mit allen Beherbergungsabgabe-/Kurtaxe-Positionen ein. Die Tabelle wird nur angezeigt, wenn entsprechende Positionen auf der Rechnung vorhanden sind.</target>
             </trans-unit>
+            <trans-unit id="templates.editor.payment_qr">
+                <source>templates.editor.payment_qr</source>
+                <target>Zahlungs-QR-Code (GiroCode)</target>
+            </trans-unit>
+            <trans-unit id="templates.editor.payment_qr.desc">
+                <source>templates.editor.payment_qr.desc</source>
+                <target>Fügt einen QR-Code ein, der in der Banking-App des Zahlenden eine SEPA-Überweisung vorausfüllt. Die Zahl ist die Auflösung des Bildes in Pixeln; wie groß es auf der Seite erscheint, bestimmt das CSS. Der Code erscheint nur, wenn in den Rechnungseinstellungen eine Bankverbindung hinterlegt ist und die Installation in Euro rechnet.</target>
+            </trans-unit>
             <trans-unit id="templates.notfound">
                 <source>templates.notfound</source>
                 <target>Es konnte keine Vorlage gefunden werden. Stelle bitte sicher, dass ein Template für die ausgewählte Aktion existiert.</target>

--- a/translations/Templates/messages.en.yaml
+++ b/translations/Templates/messages.en.yaml
@@ -73,6 +73,12 @@ templates.editor.apartment_modifier.positions.desc: >-
   last-minute discounts, pet fees). The table is only rendered when such
   positions exist on the invoice.
 templates.editor.tourist_tax.positions: Tourist tax positions
+templates.editor.payment_qr: Payment QR code (GiroCode)
+templates.editor.payment_qr.desc: >-
+  Inserts a QR code that fills a SEPA credit transfer in the payer's banking
+  app. The number is the image resolution in pixels; its size on the page comes
+  from the CSS. The code only appears when the bank details are configured in
+  the invoice settings and the installation runs in euro.
 templates.editor.tourist_tax.positions.desc: >-
   Inserts a table with all tourist-tax / accommodation-tax positions. The
   table is only rendered when such positions exist on the invoice.

--- a/translations/Templates/messages.en.yaml
+++ b/translations/Templates/messages.en.yaml
@@ -76,9 +76,10 @@ templates.editor.tourist_tax.positions: Tourist tax positions
 templates.editor.payment_qr: Payment QR code (GiroCode)
 templates.editor.payment_qr.desc: >-
   Inserts a QR code that fills a SEPA credit transfer in the payer's banking
-  app. The number is the image resolution in pixels; its size on the page comes
-  from the CSS. The code only appears when the bank details are configured in
-  the invoice settings and the installation runs in euro.
+  app. The number is the image resolution in pixels; how large it appears on the
+  page is the image's own width, which the resize handle sets. The code only
+  appears when the bank details are configured in the invoice settings and the
+  installation runs in euro.
 templates.editor.tourist_tax.positions.desc: >-
   Inserts a table with all tourist-tax / accommodation-tax positions. The
   table is only rendered when such positions exist on the invoice.


### PR DESCRIPTION
Aus der Diskussion: https://github.com/developeregrem/fewohbee/discussions/276

---

Guests retyping IBAN, amount and invoice number is where transfers stall. An
EPC069-12 payload ("GiroCode") is now offered to invoice templates through the
Twig function `payment_qr(invoice, size)`; scanning it fills a SEPA credit
transfer in the payer's banking app.

## A function, not a render parameter

The pixel size belongs to whoever lays out the template, and a parameter cannot
take one. A function is also only evaluated where it is used — building a code
costs about 20 ms, which every invoice render would otherwise pay for a
placeholder almost no template prints. Codes are memoized per invoice and size,
so guarding with an if and then printing the image builds once.

`InvoiceService` is untouched as a result.

## Nothing new to configure

The payload needs what e-invoicing already has: the issuer comes from
`EInvoiceReadinessService::resolveSettingsFor()`, which follows the invoice's
subsidiary so a two-company setup puts the right account on each code. Amount is
the gross total, remittance text the invoice number. No new settings, no
migration.

## When a code would be wrong

The function returns an empty string — missing bank details, an amount outside
the range the scheme allows, an installation running a currency other than euro
which the euro-only scheme cannot express, or a payload over the 331 bytes it
carries. The per-line caps count characters while the limit counts bytes, so an
umlaut in the account holder's name can overrun it.

Where the code appears is left to the template rather than decided in code,
because that depends on the payment method and on how each operator lays out
their invoice.

## Bounds on the requested size

Memory and time grow with the square of the edge length: 300 px costs 46 MB and
28 ms, 8000 px costs 533 MB and 5.6 seconds — a typo in a template would take
the worker down. Below roughly 80 px the encoder refuses a full-length payload
outright with "Too much data", and that exception would surface in the middle of
an invoice rather than as a missing image. Clamped to 100..1000, which is about
85 mm at 300 dpi.

## In the editor

An `<img>` whose `src` is a template expression cannot be fetched by the
browser, so the visual editor showed a broken-image icon exactly where the
picture appears at render time. The node view now paints a labelled dashed box
instead, for every image built from a placeholder rather than only for this one.

Two smaller things came out of testing that:

The resize handle asked `updateAttributes()` to change "the image", which acts
on the selection. Clicking the image first selects the node, so the drag stuck —
but grabbing the handle straight from a text selection left nothing for the
command to act on and the new width was dropped without a trace. It now
addresses the node by its position. Since an image can carry its width twice, as
the attribute and inside the style, and mPDF follows the style, the handler
rewrites both and leaves a style stating no width alone.

The snippet declares its width only as the attribute now, so there is one source
for it rather than two that have to be kept in step.

## Tests

17 unit tests on the payload and the image: line order, IBAN normalisation,
amount format, subsidiary resolution, both size bounds, the byte limit, and the
cases that must not produce a code at all.
